### PR TITLE
feat: build the project on main commits and PRs (#1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose


### PR DESCRIPTION
Add a new GitHub action to build the project on every commit on `main` and every new Pull Request. For now, we will build only the main `wws` binary. 

Closes #1