### PR TITLE
add support IPv6 hostname

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ async fn main() -> std::io::Result<()> {
 
         app
     })
-    .bind((args.hostname.as_str(), args.port))?;
+    .bind(format!("{}:{}", args.hostname.as_str(), args.port))?;
 
     println!(
         "🚀 Start serving requests at http://{}:{}\n",


### PR DESCRIPTION
on previous version
```bash
wws --host "[::]"
```

```
Error: Custom { kind: Uncategorized, error: "failed to lookup address information: nodename nor servname provided, or not known" }
```