### PR TITLE
feat: run fmt and clippy in the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Caching
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Format
+      run: cargo fmt
+    - name: Clippy
+      run: cargo clippy
     - name: Test
       run: cargo test
   build:

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ async fn wasm_handler(req: HttpRequest, body: Bytes) -> HttpResponse {
 
     for route in routes.routes.iter() {
         if route.path == req.path() {
-            let body_str = String::from_utf8(body.to_vec()).unwrap_or(String::from(""));
+            let body_str = String::from_utf8(body.to_vec()).unwrap_or_else(|_| String::from(""));
 
             // Init KV
             let kv_namespace = match &route.config {
@@ -68,10 +68,7 @@ async fn wasm_handler(req: HttpRequest, body: Bytes) -> HttpResponse {
                     let connector = data_connectors.read().unwrap();
                     let kv_store = connector.kv.find_store(namespace);
 
-                    match kv_store {
-                        Some(store) => Some(store.clone()),
-                        None => None,
-                    }
+                    kv_store.map(|store| store.clone())
                 }
                 None => None,
             };
@@ -95,7 +92,7 @@ async fn wasm_handler(req: HttpRequest, body: Bytes) -> HttpResponse {
             for (key, val) in handler_result.headers.iter() {
                 // Note that QuickJS is replacing the "-" character
                 // with "_" on property keys. Here, we rollback it
-                builder.insert_header((key.replace("_", "-").as_str(), val.as_str()));
+                builder.insert_header((key.replace('_', "-").as_str(), val.as_str()));
             }
 
             // Write to the state if required

--- a/src/router.rs
+++ b/src/router.rs
@@ -57,14 +57,14 @@ impl Route {
         Self {
             path: Self::retrieve_route(base_path, &filepath),
             handler: filepath,
-            runner: runner,
-            config: config,
+            runner,
+            config,
         }
     }
 
     // Process the given path to return the proper route for the API.
     // It will transform paths like test/index.wasm into /test.
-    fn retrieve_route(base_path: &Path, path: &PathBuf) -> String {
+    fn retrieve_route(base_path: &Path, path: &Path) -> String {
         // TODO: Improve this entire method
         // @ref #13
         if let Some(api_path) = path.to_str() {
@@ -72,7 +72,7 @@ impl Route {
                 .to_string()
                 .replace(".wasm", "")
                 .replace(".js", "")
-                .replace(base_path.to_str().unwrap_or_else(|| "./"), "");
+                .replace(base_path.to_str().unwrap_or("./"), "");
             let mut normalized = String::from("/") + &parsed_path.replace("index", "");
 
             // Remove trailing / to avoid 404 errors
@@ -83,7 +83,7 @@ impl Route {
             normalized
         } else {
             // TODO: Manage better unexpected characters in paths
-            String::from(path.to_str().unwrap_or_else(|| "/unknown"))
+            String::from(path.to_str().unwrap_or("/unknown"))
         }
     }
 }
@@ -106,7 +106,7 @@ pub fn initialize_routes(base_path: &Path) -> Vec<Route> {
     for entry in glob_items {
         match entry {
             Ok(filepath) => {
-                routes.push(Route::new(&base_path, filepath));
+                routes.push(Route::new(base_path, filepath));
             }
             Err(e) => println!("Could not read the file {:?}", e),
         }


### PR DESCRIPTION
Integrate the `cargo fmt` and `cargo clippy` tools to ensure a consistent formatting code and basic code linting in Rust. This will simplify the PR review by ensuring common best practices are considered.

In addition to that, this PR introduces a cache for the Rust project in the GitHub action. For that, we're using the official cache action from GitHub.

It closes #21 