### PR TITLE
feat: add new workflow to cross-compile wws

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -106,5 +106,3 @@ jobs:
       with:
         name: wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz
         path: ${{ env.TARBALL }}
-        # TODO: This is for testing
-        retention-days: 7

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -1,13 +1,13 @@
-name: Rust release
+name: Build artifacts
 
 on:
   push:
     branches: [ main ]
     tags:
     - "[0-9]+.[0-9]+.[0-9]+"
-  # TODO: For tesgting. Run this workflow only on a new release.
-  pull_request:
-    branches: [ main ]
+  # TODO: uncomment for testing. This will run by default only when a new tag is created
+  # pull_request:
+  #   branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,12 +97,12 @@ jobs:
           cp "target/${{ matrix.arch }}-${{ matrix.platform }}/release/wws" ./out
         fi
 
-        tar czf "wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" ./out
+        tar -C ./out czvf "wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" .
         echo "TARBALL=wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" >> $GITHUB_ENV
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
-        name: wws-${{ matrix.name }}-${{ matrix.arch }}
+        name: wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz
         path: ${{ env.TARBALL }}
         # TODO: This is for testing
         retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
             arch: aarch64
             os: ubuntu-latest
             platform: unknown-linux-musl
-            cross: false
+            cross: true
             name: linux-musl
           - build: windows
             arch: x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,6 @@ jobs:
       matrix:
         build: [linux, windows, macos]
         arch: [x86_64, aarch64]
-        exclude:
-          # Exclude win arm64 for now
-          - build: windows
-            arch: aarch64
         include:
           - build: linux
             arch: x86_64
@@ -48,6 +44,12 @@ jobs:
             name: linux-musl
           - build: windows
             arch: x86_64
+            os: windows-latest
+            platform: pc-windows-msvc
+            cross: false
+            name: pc-windows
+          - build: windows
+            arch: aarch64
             os: windows-latest
             platform: pc-windows-msvc
             cross: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
     - name: Build
       run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{ matrix.platform }}
     - name: Tarball
+      shell: bash
       run: |
         mkdir out
         cp {README.md,LICENSE} out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,11 @@ jobs:
     - name: Install target
       if: matrix.cross == false
       run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
+    - name: Install deps
+      if: matrix.build == "linux"
+      run: |
+        apt-get update
+        apt-get install musl-tools
     - name: Build
       run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{ matrix.platform }}
     - name: Tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,10 @@ jobs:
       matrix:
         build: [linux, windows, macos]
         arch: [x86_64, aarch64]
+        exclude:
+          # Exclude win arm64 for now
+          - build: windows
+            arch: aarch64
         include:
           - build: linux
             arch: x86_64
@@ -47,12 +51,6 @@ jobs:
             os: windows-latest
             platform: pc-windows-msvc
             cross: false
-            name: pc-windows
-          - build: windows
-            arch: aarch64
-            os: ubuntu-latest
-            platform: pc-windows-msvc
-            cross: true
             name: pc-windows
           - build: macos
             arch: x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       if: matrix.cross == false
       run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
     - name: Install deps
-      if: matrix.build == "linux"
+      if: matrix.build == linux
       run: |
         apt-get update
         apt-get install musl-tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
           cp "target/${{ matrix.arch }}-${{ matrix.platform }}/release/wws" ./out
         fi
 
-        tar -C ./out czvf "wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" .
+        tar czvf "wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" -C ./out .
         echo "TARBALL=wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" >> $GITHUB_ENV
     - name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
         cargo install cross
         echo "CARGO=cross" >> $GITHUB_ENV
     - name: Build
-      run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{matrix.platform}}
+      run: |
+        rustup component add rust-std-${{ matrix.arch }}-${{matrix.platform}}
+        ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{matrix.platform}}
     - name: Tarball
       run: |
         mkdir out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Rust release
 
 on:
-  releases:
-    types: [ published ]
+  push:
+    branches: [ main ]
+    tags:
+    - "[0-9]+.[0-9]+.[0-9]+"
   # TODO: For testing. Run this workflow only on a new release.
   pull_request:
     branches: [ main ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
     tags:
     - "[0-9]+.[0-9]+.[0-9]+"
-  # TODO: For testing. Run this workflow only on a new release.
+  # TODO: For tesgting. Run this workflow only on a new release.
   pull_request:
     branches: [ main ]
 
@@ -28,7 +28,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        arch: [x86_64, aarch64]
         include:
           - os: ubuntu-latest
             arch: x86_64
@@ -71,19 +70,20 @@ jobs:
       run: |
         cargo install cross
         echo "CARGO=cross" >> $GITHUB_ENV
+    - name: Install target
+      if: matrix.cross == false
+      run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
     - name: Build
-      run: |
-        rustup component add rust-std-${{ matrix.arch }}-${{matrix.platform}}
-        ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{matrix.platform}}
+      run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{ matrix.platform }}
     - name: Tarball
       run: |
         mkdir out
         cp {README.md,LICENSE} out
 
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
-          cp "target/${{ matrix.arch }}-${{matrix.platform}}/release/wws.exe" ./out
+          cp "target/${{ matrix.arch }}-${{ matrix.platform }}/release/wws.exe" ./out
         else
-          cp "target/${{ matrix.arch }}-${{matrix.platform}}/release/wws" ./out
+          cp "target/${{ matrix.arch }}-${{ matrix.platform }}/release/wws" ./out
         fi
 
         tar czf "wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" ./out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,37 +27,44 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        build: [linux, windows, macos]
+        arch: [x86_64, aarch64]
         include:
-          - os: ubuntu-latest
+          - build: linux
             arch: x86_64
+            os: ubuntu-latest
             platform: unknown-linux-musl
             cross: false
             name: linux-musl
-          - os: ubuntu-latest
+          - build: linux
             arch: aarch64
+            os: ubuntu-latest
             platform: unknown-linux-musl
             cross: true
             name: linux-musl
-          - os: windows-latest
+          - build: windows
             arch: x86_64
+            os: windows-latest
             platform: pc-windows-msvc
             cross: false
             name: pc-windows
-          - os: ubuntu-latest
+          - build: windows
             arch: aarch64
+            os: ubuntu-latest
             platform: pc-windows-msvc
             cross: true
             name: pc-windows
-          - os: macos-latest
+          - build: macos
             arch: x86_64
+            os: macos-latest
             platform: apple-darwin
             cross: false
             name: macos-darwin
-          - os: ubuntu-latest
+          - build: macos
             arch: aarch64
+            os: macos-latest
             platform: apple-darwin
-            cross: true
+            cross: false
             name: macos-darwin
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       if: matrix.cross == false
       run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
     - name: Install deps
-      if: matrix.build == linux
+      if: ${{ matrix.build == 'linux' }}
       run: |
         apt-get update
         apt-get install musl-tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Rust release
+
+on:
+  releases:
+    types: [ published ]
+  # TODO: For testing. Run this workflow only on a new release.
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Test
+      run: cargo test
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        arch: [x86_64, aarch64]
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            platform: unknown-linux-musl
+            cross: false
+            name: linux-musl
+          - os: ubuntu-latest
+            arch: aarch64
+            platform: unknown-linux-musl
+            cross: true
+            name: linux-musl
+          - os: windows-latest
+            arch: x86_64
+            platform: pc-windows-msvc
+            cross: false
+            name: pc-windows
+          - os: ubuntu-latest
+            arch: aarch64
+            platform: pc-windows-msvc
+            cross: true
+            name: pc-windows
+          - os: macos-latest
+            arch: x86_64
+            platform: apple-darwin
+            cross: false
+            name: macos-darwin
+          - os: ubuntu-latest
+            arch: aarch64
+            platform: apple-darwin
+            cross: true
+            name: macos-darwin
+    runs-on: ${{ matrix.os }}
+    env:
+      # We use cross for arm builds
+      CARGO: cargo
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install cross
+      if: matrix.cross == true
+      run: |
+        cargo install cross
+        echo "CARGO=cross" >> $GITHUB_ENV
+    - name: Build
+      run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{matrix.platform}}
+    - name: Tarball
+      run: |
+        mkdir out
+        cp {README.md,LICENSE} out
+
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          cp "target/${{ matrix.arch }}-${{matrix.platform}}/release/wws.exe" ./out
+        else
+          cp "target/${{ matrix.arch }}-${{matrix.platform}}/release/wws" ./out
+        fi
+
+        tar czf "wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" ./out
+        echo "TARBALL=wws-${{ matrix.name }}-${{ matrix.arch }}.tar.gz" >> $GITHUB_ENV
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: wws-${{ matrix.name }}-${{ matrix.arch }}
+        path: ${{ env.TARBALL }}
+        # TODO: This is for testing
+        retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,8 @@ jobs:
     - name: Install deps
       if: ${{ matrix.build == 'linux' }}
       run: |
-        apt-get update
-        apt-get install musl-tools
+        sudo apt-get update
+        sudo apt-get install musl-tools
     - name: Build
       run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{ matrix.platform }}
     - name: Tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
             arch: aarch64
             os: ubuntu-latest
             platform: unknown-linux-musl
-            cross: true
+            cross: false
             name: linux-musl
           - build: windows
             arch: x86_64


### PR DESCRIPTION
Create a new GitHub Action workflow to cross-compile Wasm Workers Server to:

- Linux
- Windows
- Mac

In both architectures:

- `x86_64`
- `aarch64`

For the `x86_64` builds, I'm using the machines provided by GitHub. In the case of `aarch64` builds, I'm using the [cross](https://github.com/cross-rs/cross) tool. This is required as GitHub is not providing `aarch64` machines.

The end goal is that the project runs this workflow to build the binaries on every new tag. The release will be crafted manually by the team to ensure release notes are correct.

It closes #6 