### PR TITLE
fix: normalize API routes using Rust path entities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   test:
-    stretegy:
+    strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,11 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    stretegy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: Caching
@@ -23,23 +27,11 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Format
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: cargo fmt
     - name: Clippy
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: cargo clippy
-    - name: Test
-      run: cargo test
-  win-test:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Caching
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Test
       run: cargo test
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,20 @@ jobs:
       run: cargo clippy
     - name: Test
       run: cargo test
+  win-test:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Test
+      run: cargo test
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Format
-      run: cargo fmt
+      run: cargo fmt --check
     - name: Clippy
       run: cargo clippy
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Caching
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Format
+      run: cargo fmt
+    - name: Clippy
+      run: cargo clippy
   test:
     strategy:
       fail-fast: false
@@ -26,12 +42,6 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Format
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: cargo fmt
-    - name: Clippy
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: cargo clippy
     - name: Test
       run: cargo test
   build:

--- a/src/router.rs
+++ b/src/router.rs
@@ -94,25 +94,19 @@ impl Route {
     // - Keep only "normal" components. Others like "." or "./" are ignored
     // - Remove "index" components
     fn normalize_path_to_url(path: &Path) -> String {
-        let no_ext_path = path.with_extension("");
-        let comps = no_ext_path.components();
-        let clean_comps = comps.filter(|c| match c {
-            Component::Normal(os_str) => os_str != &OsStr::new("index"),
-            _ => false,
-        });
-        let mut normalized_path = String::new();
-
-        for c in clean_comps {
-            let os_str = c.as_os_str();
-
-            if let Some(parsed_str) = os_str.to_str() {
-                // Force the separator to be / instead of \ in Windows
-                normalized_path.push('/');
-                normalized_path.push_str(parsed_str);
-            }
-        }
-
-        normalized_path
+        path.with_extension("")
+            .components()
+            .filter_map(|c| match c {
+                Component::Normal(os_str) if os_str != OsStr::new("index") => {
+                    if let Some(parsed_str) = os_str.to_str() {
+                        Some(String::from("/") + parsed_str)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .collect()
     }
 }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -144,47 +144,151 @@ pub fn initialize_routes(base_path: &Path) -> Vec<Route> {
 mod tests {
     use super::*;
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn unix_route_index_path_retrieval() {
-        let check_route = |path: &str, expected_route: &str| {
+        let tests = [
+            // In a subfolder
+            (".", "examples/index.js", "/examples"),
+            (".", "examples/index.wasm", "/examples"),
+            // Multiple levels
+            (".", "examples/api/index.js", "/examples/api"),
+            (".", "examples/api/index.wasm", "/examples/api"),
+            // Root
+            (".", "index.js", "/"),
+            (".", "index.wasm", "/"),
+            // Now, with a different root
+            ("./root", "root/examples/index.js", "/examples"),
+            ("./root", "root/examples/index.wasm", "/examples"),
+            ("./root", "root/examples/api/index.js", "/examples/api"),
+            ("./root", "root/examples/api/index.wasm", "/examples/api"),
+            ("./root", "root/index.js", "/"),
+            ("./root", "root/index.wasm", "/"),
+            // A backslash should not change anything
+            ("./root/", "root/examples/index.js", "/examples"),
+            ("./root/", "root/examples/index.wasm", "/examples"),
+            ("./root/", "root/examples/api/index.js", "/examples/api"),
+            ("./root/", "root/examples/api/index.wasm", "/examples/api"),
+            ("./root/", "root/index.js", "/"),
+            ("./root/", "root/index.wasm", "/"),
+        ];
+
+        for t in tests {
             assert_eq!(
-                Route::retrieve_route(&Path::new("."), &PathBuf::from(path)),
-                String::from(expected_route),
+                Route::retrieve_route(&Path::new(t.0), &PathBuf::from(t.1)),
+                String::from(t.2),
             )
-        };
-
-        // In a subfolder
-        check_route("examples/index.js", "/examples");
-        check_route("examples/index.wasm", "/examples");
-
-        // Multiple levels
-        check_route("examples/api/index.js", "/examples/api");
-        check_route("examples/api/index.wasm", "/examples/api");
-
-        // Root
-        check_route("index.js", "/");
-        check_route("index.wasm", "/");
+        }
     }
 
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn win_route_index_path_retrieval() {
+        let tests = [
+            // In a subfolder
+            (".", "examples\\index.js", "/examples"),
+            (".", "examples\\index.wasm", "/examples"),
+            // Multiple levels
+            (".", "examples\\api\\index.js", "/examples/api"),
+            (".", "examples\\api\\index.wasm", "/examples/api"),
+            // Root
+            (".", "index.js", "/"),
+            (".", "index.wasm", "/"),
+            // Now, with a different root
+            (".\\root", "root\\examples\\index.js", "/examples"),
+            (".\\root", "root\\examples\\index.wasm", "/examples"),
+            (".\\root", "root\\examples\\api\\index.js", "/examples/api"),
+            (".\\root", "root\\examples\\api\\index.wasm", "/examples/api"),
+            (".\\root", "root\\index.js", "/"),
+            (".\\root", "root\\index.wasm", "/"),
+            // A backslash should not change anything
+            (".\\root\\", "root\\examples\\index.js", "/examples"),
+            (".\\root\\", "root\\examples\\index.wasm", "/examples"),
+            (".\\root\\", "root\\examples\\api\\index.js", "/examples/api"),
+            (".\\root\\", "root\\examples\\api\\index.wasm", "/examples/api"),
+            (".\\root\\", "root\\index.js", "/"),
+            (".\\root\\", "root\\index.wasm", "/"),
+        ];
+
+        for t in tests {
+            assert_eq!(
+                Route::retrieve_route(&Path::new(t.0), &PathBuf::from(t.1)),
+                String::from(t.2),
+            )
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn unix_route_path_retrieval() {
-        let check_route = |path: &str, expected_route: &str| {
+        let tests = [
+            // In a subfolder
+            (".", "examples/handler.js", "/examples/handler"),
+            (".", "examples/handler.wasm", "/examples/handler"),
+            // Multiple levels
+            (".", "examples/api/handler.js", "/examples/api/handler"),
+            (".", "examples/api/handler.wasm", "/examples/api/handler"),
+            // Root
+            (".", "handler.js", "/handler"),
+            (".", "handler.wasm", "/handler"),
+            // Now, with a different root
+            ("./root", "root/examples/handler.js", "/examples/handler"),
+            ("./root", "root/examples/handler.wasm", "/examples/handler"),
+            ("./root", "root/examples/api/handler.js", "/examples/api/handler"),
+            ("./root", "root/examples/api/handler.wasm", "/examples/api/handler"),
+            ("./root", "root/handler.js", "/handler"),
+            ("./root", "root/handler.wasm", "/handler"),
+            // A backslash should not change anything
+            ("./root/", "root/examples/handler.js", "/examples/handler"),
+            ("./root/", "root/examples/handler.wasm", "/examples/handler"),
+            ("./root/", "root/examples/api/handler.js", "/examples/api/handler"),
+            ("./root/", "root/examples/api/handler.wasm", "/examples/api/handler"),
+            ("./root/", "root/handler.js", "/handler"),
+            ("./root/", "root/handler.wasm", "/handler"),
+        ];
+
+        for t in tests {
             assert_eq!(
-                Route::retrieve_route(&Path::new("."), &PathBuf::from(path)),
-                String::from(expected_route),
+                Route::retrieve_route(&Path::new(t.0), &PathBuf::from(t.1)),
+                String::from(t.2),
             )
-        };
+        }
+    }
 
-        // In a subfolder
-        check_route("examples/handler.js", "/examples/handler");
-        check_route("examples/handler.wasm", "/examples/handler");
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn win_route_path_retrieval() {
+        let tests = [
+            // In a subfolder
+            (".", "examples\\handler.js", "/examples/handler"),
+            (".", "examples\\handler.wasm", "/examples/handler"),
+            // Multiple levels
+            (".", "examples\\api\\handler.js", "/examples/api/handler"),
+            (".", "examples\\api\\handler.wasm", "/examples/api/handler"),
+            // Root
+            (".", "handler.js", "/handler"),
+            (".", "handler.wasm", "/handler"),
+            // Now, with a different root
+            (".\\root", "root\\examples\\handler.js", "/examples/handler"),
+            (".\\root", "root\\examples\\handler.wasm", "/examples/handler"),
+            (".\\root", "root\\examples\\api\\handler.js", "/examples/api/handler"),
+            (".\\root", "root\\examples\\api\\handler.wasm", "/examples/api/handler"),
+            (".\\root", "root\\handler.js", "/handler"),
+            (".\\root", "root\\handler.wasm", "/handler"),
+            // A backslash should not change anything
+            (".\\root\\", "root\\examples\\handler.js", "/examples/handler"),
+            (".\\root\\", "root\\examples\\handler.wasm", "/examples/handler"),
+            (".\\root\\", "root\\examples\\api\\handler.js", "/examples/api/handler"),
+            (".\\root\\", "root\\examples\\api\\handler.wasm", "/examples/api/handler"),
+            (".\\root\\", "root\\handler.js", "/handler"),
+            (".\\root\\", "root\\handler.wasm", "/handler"),
+        ];
 
-        // Multiple levels
-        check_route("examples/api/handler.js", "/examples/api/handler");
-        check_route("examples/api/handler.wasm", "/examples/api/handler");
-
-        // Root
-        check_route("handler.js", "/handler");
-        check_route("handler.wasm", "/handler");
+        for t in tests {
+            assert_eq!(
+                Route::retrieve_route(&Path::new(t.0), &PathBuf::from(t.1)),
+                String::from(t.2),
+            )
+        }
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -149,6 +149,7 @@ pub fn initialize_routes(base_path: &Path) -> Vec<Route> {
 mod tests {
     use super::*;
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn unix_route_index_path_retrieval() {
         let tests = [
@@ -185,6 +186,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "windows")]
     #[test]
     fn win_route_index_path_retrieval() {
         let tests = [
@@ -221,6 +223,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn unix_route_path_retrieval() {
         let tests = [
@@ -257,6 +260,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "windows")]
     #[test]
     fn win_route_path_retrieval() {
         let tests = [

--- a/src/router.rs
+++ b/src/router.rs
@@ -186,28 +186,28 @@ mod tests {
     fn win_route_index_path_retrieval() {
         let tests = [
             // In a subfolder
-            (".", "examples\\index.js", "/examples"),
-            (".", "examples\\index.wasm", "/examples"),
+            (".", "examples/index.js", "/examples"),
+            (".", "examples/index.wasm", "/examples"),
             // Multiple levels
-            (".", "examples\\api\\index.js", "/examples/api"),
-            (".", "examples\\api\\index.wasm", "/examples/api"),
+            (".", "examples/api/index.js", "/examples/api"),
+            (".", "examples/api/index.wasm", "/examples/api"),
             // Root
             (".", "index.js", "/"),
             (".", "index.wasm", "/"),
             // Now, with a different root
-            (".\\root", "root\\examples\\index.js", "/examples"),
-            (".\\root", "root\\examples\\index.wasm", "/examples"),
-            (".\\root", "root\\examples\\api\\index.js", "/examples/api"),
-            (".\\root", "root\\examples\\api\\index.wasm", "/examples/api"),
-            (".\\root", "root\\index.js", "/"),
-            (".\\root", "root\\index.wasm", "/"),
+            (".\\root", "root/examples/index.js", "/examples"),
+            (".\\root", "root/examples/index.wasm", "/examples"),
+            (".\\root", "root/examples/api/index.js", "/examples/api"),
+            (".\\root", "root/examples/api/index.wasm", "/examples/api"),
+            (".\\root", "root/index.js", "/"),
+            (".\\root", "root/index.wasm", "/"),
             // A backslash should not change anything
-            (".\\root\\", "root\\examples\\index.js", "/examples"),
-            (".\\root\\", "root\\examples\\index.wasm", "/examples"),
-            (".\\root\\", "root\\examples\\api\\index.js", "/examples/api"),
-            (".\\root\\", "root\\examples\\api\\index.wasm", "/examples/api"),
-            (".\\root\\", "root\\index.js", "/"),
-            (".\\root\\", "root\\index.wasm", "/"),
+            (".\\root\\", "root/examples/index.js", "/examples"),
+            (".\\root\\", "root/examples/index.wasm", "/examples"),
+            (".\\root\\", "root/examples/api/index.js", "/examples/api"),
+            (".\\root\\", "root/examples/api/index.wasm", "/examples/api"),
+            (".\\root\\", "root/index.js", "/"),
+            (".\\root\\", "root/index.wasm", "/"),
         ];
 
         for t in tests {
@@ -260,28 +260,28 @@ mod tests {
     fn win_route_path_retrieval() {
         let tests = [
             // In a subfolder
-            (".", "examples\\handler.js", "/examples/handler"),
-            (".", "examples\\handler.wasm", "/examples/handler"),
+            (".", "examples/handler.js", "/examples/handler"),
+            (".", "examples/handler.wasm", "/examples/handler"),
             // Multiple levels
-            (".", "examples\\api\\handler.js", "/examples/api/handler"),
-            (".", "examples\\api\\handler.wasm", "/examples/api/handler"),
+            (".", "examples/api/handler.js", "/examples/api/handler"),
+            (".", "examples/api/handler.wasm", "/examples/api/handler"),
             // Root
             (".", "handler.js", "/handler"),
             (".", "handler.wasm", "/handler"),
             // Now, with a different root
-            (".\\root", "root\\examples\\handler.js", "/examples/handler"),
-            (".\\root", "root\\examples\\handler.wasm", "/examples/handler"),
-            (".\\root", "root\\examples\\api\\handler.js", "/examples/api/handler"),
-            (".\\root", "root\\examples\\api\\handler.wasm", "/examples/api/handler"),
-            (".\\root", "root\\handler.js", "/handler"),
-            (".\\root", "root\\handler.wasm", "/handler"),
+            (".\\root", "root/examples/handler.js", "/examples/handler"),
+            (".\\root", "root/examples/handler.wasm", "/examples/handler"),
+            (".\\root", "root/examples/api/handler.js", "/examples/api/handler"),
+            (".\\root", "root/examples/api/handler.wasm", "/examples/api/handler"),
+            (".\\root", "root/handler.js", "/handler"),
+            (".\\root", "root/handler.wasm", "/handler"),
             // A backslash should not change anything
-            (".\\root\\", "root\\examples\\handler.js", "/examples/handler"),
-            (".\\root\\", "root\\examples\\handler.wasm", "/examples/handler"),
-            (".\\root\\", "root\\examples\\api\\handler.js", "/examples/api/handler"),
-            (".\\root\\", "root\\examples\\api\\handler.wasm", "/examples/api/handler"),
-            (".\\root\\", "root\\handler.js", "/handler"),
-            (".\\root\\", "root\\handler.wasm", "/handler"),
+            (".\\root\\", "root/examples/handler.js", "/examples/handler"),
+            (".\\root\\", "root/examples/handler.wasm", "/examples/handler"),
+            (".\\root\\", "root/examples/api/handler.js", "/examples/api/handler"),
+            (".\\root\\", "root/examples/api/handler.wasm", "/examples/api/handler"),
+            (".\\root\\", "root/handler.js", "/handler"),
+            (".\\root\\", "root/handler.wasm", "/handler"),
         ];
 
         for t in tests {

--- a/src/router.rs
+++ b/src/router.rs
@@ -8,9 +8,9 @@
 use crate::config::Config;
 use crate::runner::Runner;
 use glob::glob;
-use std::fs;
-use std::path::{Path, PathBuf, Component};
 use std::ffi::OsStr;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
 
 /// An existing route in the project. It contains a reference to the handler, the URL path,
 /// the runner and configuration. Note that URL paths are calculated based on the file path.
@@ -73,13 +73,13 @@ impl Route {
         // Remove the base_path
         match n_path.strip_prefix(&n_base_path) {
             Some(worker_path) => {
-                if worker_path.len() == 0 {
+                if worker_path.is_empty() {
                     // Index file at root
                     String::from("/")
                 } else {
                     worker_path.to_string()
                 }
-            },
+            }
             None => {
                 // TODO: manage errors properly and skip the route
                 // @see #13
@@ -96,20 +96,18 @@ impl Route {
     fn normalize_path_to_url(path: &Path) -> String {
         let no_ext_path = path.with_extension("");
         let comps = no_ext_path.components();
-        let clean_comps = comps.filter(|c|
-            match c {
-                Component::Normal(os_str) => os_str != &OsStr::new("index"),
-                _ => false
-            }
-        );
+        let clean_comps = comps.filter(|c| match c {
+            Component::Normal(os_str) => os_str != &OsStr::new("index"),
+            _ => false,
+        });
         let mut normalized_path = String::new();
 
-        for c in clean_comps.into_iter() {
+        for c in clean_comps {
             let os_str = c.as_os_str();
 
             if let Some(parsed_str) = os_str.to_str() {
                 // Force the separator to be / instead of \ in Windows
-                normalized_path.push_str("/");
+                normalized_path.push('/');
                 normalized_path.push_str(parsed_str);
             }
         }
@@ -203,14 +201,26 @@ mod tests {
             (".\\root", "root\\examples\\index.js", "/examples"),
             (".\\root", "root\\examples\\index.wasm", "/examples"),
             (".\\root", "root\\examples\\api\\index.js", "/examples/api"),
-            (".\\root", "root\\examples\\api\\index.wasm", "/examples/api"),
+            (
+                ".\\root",
+                "root\\examples\\api\\index.wasm",
+                "/examples/api",
+            ),
             (".\\root", "root\\index.js", "/"),
             (".\\root", "root\\index.wasm", "/"),
             // A backslash should not change anything
             (".\\root\\", "root\\examples\\index.js", "/examples"),
             (".\\root\\", "root\\examples\\index.wasm", "/examples"),
-            (".\\root\\", "root\\examples\\api\\index.js", "/examples/api"),
-            (".\\root\\", "root\\examples\\api\\index.wasm", "/examples/api"),
+            (
+                ".\\root\\",
+                "root\\examples\\api\\index.js",
+                "/examples/api",
+            ),
+            (
+                ".\\root\\",
+                "root\\examples\\api\\index.wasm",
+                "/examples/api",
+            ),
             (".\\root\\", "root\\index.js", "/"),
             (".\\root\\", "root\\index.wasm", "/"),
         ];
@@ -239,15 +249,31 @@ mod tests {
             // Now, with a different root
             ("./root", "root/examples/handler.js", "/examples/handler"),
             ("./root", "root/examples/handler.wasm", "/examples/handler"),
-            ("./root", "root/examples/api/handler.js", "/examples/api/handler"),
-            ("./root", "root/examples/api/handler.wasm", "/examples/api/handler"),
+            (
+                "./root",
+                "root/examples/api/handler.js",
+                "/examples/api/handler",
+            ),
+            (
+                "./root",
+                "root/examples/api/handler.wasm",
+                "/examples/api/handler",
+            ),
             ("./root", "root/handler.js", "/handler"),
             ("./root", "root/handler.wasm", "/handler"),
             // A backslash should not change anything
             ("./root/", "root/examples/handler.js", "/examples/handler"),
             ("./root/", "root/examples/handler.wasm", "/examples/handler"),
-            ("./root/", "root/examples/api/handler.js", "/examples/api/handler"),
-            ("./root/", "root/examples/api/handler.wasm", "/examples/api/handler"),
+            (
+                "./root/",
+                "root/examples/api/handler.js",
+                "/examples/api/handler",
+            ),
+            (
+                "./root/",
+                "root/examples/api/handler.wasm",
+                "/examples/api/handler",
+            ),
             ("./root/", "root/handler.js", "/handler"),
             ("./root/", "root/handler.wasm", "/handler"),
         ];
@@ -275,16 +301,44 @@ mod tests {
             (".", "handler.wasm", "/handler"),
             // Now, with a different root
             (".\\root", "root\\examples\\handler.js", "/examples/handler"),
-            (".\\root", "root\\examples\\handler.wasm", "/examples/handler"),
-            (".\\root", "root\\examples\\api\\handler.js", "/examples/api/handler"),
-            (".\\root", "root\\examples\\api\\handler.wasm", "/examples/api/handler"),
+            (
+                ".\\root",
+                "root\\examples\\handler.wasm",
+                "/examples/handler",
+            ),
+            (
+                ".\\root",
+                "root\\examples\\api\\handler.js",
+                "/examples/api/handler",
+            ),
+            (
+                ".\\root",
+                "root\\examples\\api\\handler.wasm",
+                "/examples/api/handler",
+            ),
             (".\\root", "root\\handler.js", "/handler"),
             (".\\root", "root\\handler.wasm", "/handler"),
             // A backslash should not change anything
-            (".\\root\\", "root\\examples\\handler.js", "/examples/handler"),
-            (".\\root\\", "root\\examples\\handler.wasm", "/examples/handler"),
-            (".\\root\\", "root\\examples\\api\\handler.js", "/examples/api/handler"),
-            (".\\root\\", "root\\examples\\api\\handler.wasm", "/examples/api/handler"),
+            (
+                ".\\root\\",
+                "root\\examples\\handler.js",
+                "/examples/handler",
+            ),
+            (
+                ".\\root\\",
+                "root\\examples\\handler.wasm",
+                "/examples/handler",
+            ),
+            (
+                ".\\root\\",
+                "root\\examples\\api\\handler.js",
+                "/examples/api/handler",
+            ),
+            (
+                ".\\root\\",
+                "root\\examples\\api\\handler.wasm",
+                "/examples/api/handler",
+            ),
             (".\\root\\", "root\\handler.js", "/handler"),
             (".\\root\\", "root\\handler.wasm", "/handler"),
         ];


### PR DESCRIPTION
In the current `main`  version, file paths are not normalized properlies as APIs. This is causing inconsistent behaviors in different environments:

- In unix, the API path includes the root folder the CLI receives as argument. For example, for `wws ./examples/js-basic`, the URL of the `handler.js` should be `/handler`. Note that ` ./examples/js-basic` is the local folder to read the files, not a prefix for the final URL. However, the HTTP endpoint it generates is `/examples/js-basic/handler.
- In windows, it just doesn't work. The `handler.js` is not accessible (See [1]).

This is mainly caused by converting file paths to string and apply transformations later. Since paths may include special components such as `.`  and `./`, applying operations like `replace` can have different outcomes depending on the environment. This also causes inconsistent behaviors when a final backslash is added or not to the CLI argument.

In this PR, I changed that implementation to run all required transformations directly on the path. Instead of replacing and subtracting from a converted string, I iterate over the components to remove any special entity and keep only the [Normal ones](https://doc.rust-lang.org/std/path/enum.Component.html). Finally, I convert them to a String to be used as the API path.

I tested the current changes on both Windows and Mac (Unix) and they work great:

![win_working](https://user-images.githubusercontent.com/4056725/202425895-a8e34ceb-0c5a-4730-905a-efe1d48be98b.PNG)

[1]
![win_err](https://user-images.githubusercontent.com/4056725/202425196-5dfb815a-c16c-474d-ace4-12c9b7b35e26.PNG)
![win_err2](https://user-images.githubusercontent.com/4056725/202425202-da197219-dd9d-4f24-bb5d-872f7586de36.PNG)

It closes #30 