### PR TITLE
feat: add the prefix option to prepend a path to all URLs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,8 @@ struct Args {
     path: PathBuf,
 
     /// Prepend the given path to all URLs
-    #[clap(long)]
-    prefix: Option<String>,
+    #[clap(long, default_value = "")]
+    prefix: String,
 }
 
 // Common structures
@@ -168,7 +168,7 @@ async fn main() -> std::io::Result<()> {
     env_logger::init();
 
     // Initialize the prefix
-    let prefix = router::format_prefix(args.prefix.to_owned());
+    let prefix = router::format_prefix(&args.prefix);
 
     println!("⚙️  Loading routes from: {}", &args.path.display());
     let routes = Data::new(Routes {

--- a/src/router.rs
+++ b/src/router.rs
@@ -149,8 +149,8 @@ pub fn initialize_routes(base_path: &Path, prefix: &str) -> Vec<Route> {
 /// \app. This shouldn't be considered as "prefix" must be an URI
 /// path. However, the check is pretty simple, so we will consider
 /// it.
-pub fn format_prefix(source: Option<String>) -> String {
-    let mut normalized_prefix = source.unwrap_or_default();
+pub fn format_prefix(source: &str) -> String {
+    let mut normalized_prefix = source.to_string();
     // Ensure the prefix doesn't include any \ character
     normalized_prefix = normalized_prefix.replace('\\', "/");
 
@@ -376,26 +376,25 @@ mod tests {
     }
 
     #[test]
-    fn format_optional_prefix() {
+    fn format_provided_prefix() {
         let tests = [
             // Unix approach
-            (Some(String::from("")), ""),
-            (Some(String::from("/app")), "/app"),
-            (Some(String::from("app")), "/app"),
-            (Some(String::from("app/")), "/app"),
-            (Some(String::from("/app/")), "/app"),
-            (Some(String::from("/app/test/")), "/app/test"),
-            (Some(String::from("/app/test")), "/app/test"),
-            (Some(String::from("app/test/")), "/app/test"),
+            ("", ""),
+            ("/app", "/app"),
+            ("app", "/app"),
+            ("app/", "/app"),
+            ("/app/", "/app"),
+            ("/app/test/", "/app/test"),
+            ("/app/test", "/app/test"),
+            ("app/test/", "/app/test"),
             // Windows approach
-            (Some(String::from("\\app")), "/app"),
-            (Some(String::from("app")), "/app"),
-            (Some(String::from("app\\")), "/app"),
-            (Some(String::from("\\app\\")), "/app"),
-            (Some(String::from("\\app\\test\\")), "/app/test"),
-            (Some(String::from("\\app\\test")), "/app/test"),
-            (Some(String::from("app\\test\\")), "/app/test"),
-            (None, ""),
+            ("\\app", "/app"),
+            ("app", "/app"),
+            ("app\\", "/app"),
+            ("\\app\\", "/app"),
+            ("\\app\\test\\", "/app/test"),
+            ("\\app\\test", "/app/test"),
+            ("app\\test\\", "/app/test"),
         ];
 
         for t in tests {

--- a/src/router.rs
+++ b/src/router.rs
@@ -154,7 +154,9 @@ pub fn format_prefix(source: &str) -> String {
     // Ensure the prefix doesn't include any \ character
     normalized_prefix = normalized_prefix.replace('\\', "/");
 
-    if !normalized_prefix.is_empty() {
+    if normalized_prefix.is_empty() {
+        normalized_prefix
+    } else {
         if !normalized_prefix.starts_with('/') {
             normalized_prefix = String::from('/') + &normalized_prefix;
         }
@@ -162,9 +164,9 @@ pub fn format_prefix(source: &str) -> String {
         if normalized_prefix.ends_with('/') {
             normalized_prefix.pop();
         }
-    }
 
-    normalized_prefix
+        normalized_prefix
+    }
 }
 
 #[cfg(test)]
@@ -202,7 +204,7 @@ mod tests {
 
         for t in tests {
             assert_eq!(
-                Route::retrieve_route(&Path::new(t.0), &PathBuf::from(t.1), ""),
+                Route::retrieve_route(Path::new(t.0), &PathBuf::from(t.1), ""),
                 String::from(t.2),
             )
         }
@@ -304,7 +306,7 @@ mod tests {
 
         for t in tests {
             assert_eq!(
-                Route::retrieve_route(&Path::new(t.0), &PathBuf::from(t.1), ""),
+                Route::retrieve_route(Path::new(t.0), &PathBuf::from(t.1), ""),
                 String::from(t.2),
             )
         }

--- a/src/router.rs
+++ b/src/router.rs
@@ -129,7 +129,7 @@ pub fn initialize_routes(base_path: &Path, prefix: &str) -> Vec<Route> {
     for entry in glob_items {
         match entry {
             Ok(filepath) => {
-                routes.push(Route::new(base_path, filepath, &prefix));
+                routes.push(Route::new(base_path, filepath, prefix));
             }
             Err(e) => println!("Could not read the file {:?}", e),
         }
@@ -150,9 +150,9 @@ pub fn initialize_routes(base_path: &Path, prefix: &str) -> Vec<Route> {
 /// path. However, the check is pretty simple, so we will consider
 /// it.
 pub fn format_prefix(source: Option<String>) -> String {
-    let mut normalized_prefix = source.unwrap_or_else(|| String::new());
+    let mut normalized_prefix = source.unwrap_or_default();
     // Ensure the prefix doesn't include any \ character
-    normalized_prefix = normalized_prefix.replace("\\", "/");
+    normalized_prefix = normalized_prefix.replace('\\', "/");
 
     if !normalized_prefix.is_empty() {
         if !normalized_prefix.starts_with('/') {


### PR DESCRIPTION
Introduce a new `--prefix` option to preped a string to all URLs (workers and static assets). This option receives a string that will be properly normalized by the application. If no option is provided, the default value will be "" (no prefix).

This is the outcome from the `--help` command:

```
~/W/o/webassembly-functionless ❯❯❯ cargo run -- --help

Wasm Workers Server is a blazing-fast self-contained server that routes HTTP requests to workers in your filesystem. Everything run in a WebAssembly sandbox

Usage: wws [OPTIONS] [PATH]

Arguments:
  [PATH]  Folder to read WebAssembly modules from [default: .]

Options:
      --host <HOSTNAME>  Hostname to initiate the server [default: 127.0.0.1]
  -p, --port <PORT>      Port to initiate the server [default: 8080]
      --prefix <PREFIX>  Prepend the given path to all URLs
  -h, --help             Print help information
  -V, --version          Print version information
```

Note that this string must use URI format (`/X/Y`) because it's not a filesystem path. However, I also considered the case that someone introduces a windows path (`\X\Y`). I considered it because it's easy to implement, but I may drop support in the future.

It closes #31 