### PR TITLE
fix: avoid service JS files inside public folder as worker

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -422,7 +422,7 @@ mod tests {
             assert_eq!(is_in_public_folder(&Path::new(t.0)), t.1)
         }
     }
-    
+
     #[test]
     fn format_provided_prefix() {
         let tests = [

--- a/src/router.rs
+++ b/src/router.rs
@@ -127,14 +127,24 @@ pub fn initialize_routes(base_path: &Path) -> Vec<Route> {
 
     for entry in glob_items {
         match entry {
-            Ok(filepath) => {
+            // Avoid loading static assets
+            Ok(filepath) if !is_in_public_folder(&filepath) => {
                 routes.push(Route::new(base_path, filepath));
             }
             Err(e) => println!("Could not read the file {:?}", e),
+            _ => {}
         }
     }
 
     routes
+}
+
+/// Checks if the given filepath is inside the "public" folder
+fn is_in_public_folder(path: &Path) -> bool {
+    path.components().any(|c| match c {
+        Component::Normal(os_str) => os_str == OsStr::new("public"),
+        _ => false,
+    })
 }
 
 #[cfg(test)]
@@ -342,6 +352,42 @@ mod tests {
                 Route::retrieve_route(&Path::new(t.0), &PathBuf::from(t.1)),
                 String::from(t.2),
             )
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn unix_is_in_public_folder() {
+        let tests = [
+            ("public/index.js", true),
+            ("examples/public/index.js", true),
+            ("examples/public/other.js", true),
+            ("public.js", false),
+            ("examples/public.js", false),
+            ("./examples/public.js", false),
+            ("./examples/index.js", false),
+        ];
+
+        for t in tests {
+            assert_eq!(is_in_public_folder(&Path::new(t.0)), t.1,)
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn win_is_in_public_folder() {
+        let tests = [
+            ("public\\index.js", true),
+            ("examples\\public\\index.js", true),
+            ("examples\\public\\other.js", true),
+            ("public.js", false),
+            ("examples\\public.js", false),
+            (".\\examples\\public.js", false),
+            (".\\examples\\index.js", false),
+        ];
+
+        for t in tests {
+            assert_eq!(is_in_public_folder(&Path::new(t.0)), t.1,)
         }
     }
 }


### PR DESCRIPTION
Ensure that assets in the `public` folder are always served as static. Before this PR, `.js` files inside the `public` folder will be processed as workers.

It closes #36 