### PR TITLE
fix: make vars section optional in the configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     /// Optional data configuration
     pub data: Option<ConfigData>,
     /// Optional environment configuration
-    #[serde(deserialize_with = "read_environment_variables")]
+    #[serde(deserialize_with = "read_environment_variables", default)]
     pub vars: HashMap<String, String>,
 }
 


### PR DESCRIPTION
Add a default value for `vars` configuration when it's not available. This make the element optional in the configuration.

It closes #49 