### PR TITLE
feat: automate container build with GitHub Actions

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
-  # TODO: uncomment for testing. This will run by default only when a new tag is created
-  # pull_request:
-  #   branches: [ main ]
 
 jobs:
   test:
@@ -59,7 +56,8 @@ jobs:
             name: macos-darwin
     runs-on: ${{ matrix.os }}
     env:
-      # We use cross for arm builds
+      # This variable can be overriden with `cross` for builds that
+      # requires it. By default, we will compile everything using cargo.
       CARGO: cargo
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/container-preview.yml
+++ b/.github/workflows/container-preview.yml
@@ -1,0 +1,39 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  # TODO: uncomment for testing. This will run by default only when a new commit is push to main
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  IMAGE_NAME: vmware-labs/wws
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Repository clone
+      uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: image/Dockerfile
+          # TODO: First check the compilation and then
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:preview

--- a/.github/workflows/container-preview.yml
+++ b/.github/workflows/container-preview.yml
@@ -5,9 +5,6 @@ name: Container Build Preview
 on:
   push:
     branches: [ "main" ]
-  # TODO: uncomment for testing. This will run by default only when a new commit is push to main
-  # pull_request:
-  #   branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -29,7 +26,8 @@ jobs:
             cross: true
             platform: unknown-linux-musl
     env:
-      # We use cross for arm builds
+      # This variable can be overriden with `cross` for builds that
+      # requires it. By default, we will compile everything using cargo.
       CARGO: cargo
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/container-preview.yml
+++ b/.github/workflows/container-preview.yml
@@ -29,11 +29,11 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: image/Dockerfile
-          # TODO: First check the compilation and then
-          push: false
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:preview
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        file: image/Dockerfile
+        # TODO: First check the compilation and then
+        push: false
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:preview

--- a/.github/workflows/container-preview.yml
+++ b/.github/workflows/container-preview.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Container Build Preview
 
 on:
   push:
@@ -13,7 +13,7 @@ env:
   IMAGE_NAME: vmware-labs/wws
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Repository clone
@@ -22,7 +22,7 @@ jobs:
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
-    - name: Login to Docker Hub
+    - name: Login to GitHub Package Registry
       uses: docker/login-action@v2
       with:
         registry: ${{ env.REGISTRY }}

--- a/.github/workflows/container-preview.yml
+++ b/.github/workflows/container-preview.yml
@@ -47,12 +47,12 @@ jobs:
         sudo apt-get update
         sudo apt-get install musl-tools
     - name: Build
-      run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{ matrix.platform }}
+      run: ${{env.CARGO}} build --release --target=${{ matrix.arch }}-${{ matrix.platform }}
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:
-        name: target/${{ matrix.arch }}-${{ matrix.platform }}/release/wws
-        path: wws-${{ matrix.arch }}
+        name: wws-${{ matrix.arch }}
+        path: target/${{ matrix.arch }}-${{ matrix.platform }}/release/wws
 
   build-container-image:
     name: Build Container Image

--- a/.github/workflows/container-preview.yml
+++ b/.github/workflows/container-preview.yml
@@ -1,3 +1,5 @@
+# Copyright 2022 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
 name: Container Build Preview
 
 on:
@@ -13,8 +15,50 @@ env:
   IMAGE_NAME: vmware-labs/wws
 
 jobs:
-  build:
+  build-binaries:
+    name: Build Rust binaries
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [ "aarch64", "x86_64" ]
+        include:
+          - arch: x86_64
+            cross: false
+            platform: unknown-linux-musl
+          - arch: aarch64
+            cross: true
+            platform: unknown-linux-musl
+    env:
+      # We use cross for arm builds
+      CARGO: cargo
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install cross
+      if: matrix.cross == true
+      run: |
+        cargo install cross
+        echo "CARGO=cross" >> $GITHUB_ENV
+    - name: Install target
+      if: matrix.cross == false
+      run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
+    - name: Install deps
+      if: matrix.cross == false
+      run: |
+        sudo apt-get update
+        sudo apt-get install musl-tools
+    - name: Build
+      run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{ matrix.platform }}
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: target/${{ matrix.arch }}-${{ matrix.platform }}/release/wws
+        path: wws-${{ matrix.arch }}
+
+  build-container-image:
+    name: Build Container Image
+    runs-on: ubuntu-latest
+    needs:
+     - build-binaries
     steps:
     - name: Repository clone
       uses: actions/checkout@v3
@@ -28,12 +72,25 @@ jobs:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Download wws-x86_64
+      uses: actions/download-artifact@v3
+      with:
+        name: wws-x86_64
+        path: binaries
+    - name: Download wws-aarch64
+      uses: actions/download-artifact@v3
+      with:
+        name: wws-aarch64
+        path: binaries
+    - name: Move binaries and rename
+      run: |
+        mv binaries/wws-x86_64 wws-amd64
+        mv binaries/wws-aarch64 wws-arm64
     - name: Build and push
       uses: docker/build-push-action@v3
       with:
         context: .
-        file: image/Dockerfile
-        # TODO: First check the compilation and then
-        push: false
+        file: image/Prebuilt.dockerfile
+        push: true
         platforms: linux/amd64,linux/arm64
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:preview

--- a/.github/workflows/container-preview.yml
+++ b/.github/workflows/container-preview.yml
@@ -76,16 +76,16 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: wws-x86_64
-        path: binaries
+        path: binaries/x86_64
     - name: Download wws-aarch64
       uses: actions/download-artifact@v3
       with:
         name: wws-aarch64
-        path: binaries
+        path: binaries/aarch64
     - name: Move binaries and rename
       run: |
-        mv binaries/wws-x86_64 wws-amd64
-        mv binaries/wws-aarch64 wws-arm64
+        mv binaries/x86_64/wws wws-amd64
+        mv binaries/aarch64/wws wws-arm64
     - name: Build and push
       uses: docker/build-push-action@v3
       with:

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -6,9 +6,6 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
-  # TODO: uncomment for testing. This will run by default only when a new commit is push to main
-  # pull_request:
-  #   branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -30,7 +27,8 @@ jobs:
             cross: true
             platform: unknown-linux-musl
     env:
-      # We use cross for arm builds
+      # This variable can be overriden with `cross` for builds that
+      # requires it. By default, we will compile everything using cargo.
       CARGO: cargo
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -1,10 +1,11 @@
 # Copyright 2022 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
-name: Container Build Preview
+name: Container Build Release
 
 on:
   push:
-    branches: [ "main" ]
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"
   # TODO: uncomment for testing. This will run by default only when a new commit is push to main
   # pull_request:
   #   branches: [ "main" ]
@@ -93,4 +94,4 @@ jobs:
         file: image/Prebuilt.dockerfile
         push: true
         platforms: linux/amd64,linux/arm64
-        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:preview
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -15,6 +15,7 @@ RUN echo "Running on ${BUILDPLATFORM}, building for ${TARGETPLATFORM}"
 
 # Switch to nightly to avoid memory issues when pulling Crates.io
 # https://github.com/rust-lang/cargo/issues/10781
+RUN apt-get update && apt-get install -y musl
 RUN set -eux; \
     ls -l .; \
     case "${TARGETPLATFORM}" in \

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,41 +1,31 @@
-# Build Wasm Workers in release mode. This is a multiplatform
-# container, so we ensure we build it for amd64 and arm64.
-# This will require the Rust configuration to change when
-# building the project
-FROM --platform=$TARGETPLATFORM rust:1.65.0-slim as build-wws
+# Build wasm_runtime in release mode
+
+
+FROM --platform=$TARGETPLATFORM rust:1.64.0-slim as build-wws
 ARG WWS_BUILD_DIR=/usr/src/wws
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 WORKDIR $WWS_BUILD_DIR
-# Only copy required files
-COPY ./Cargo.* $WWS_BUILD_DIR/
-COPY ./src $WWS_BUILD_DIR/src
-COPY ./kits $WWS_BUILD_DIR/kits
+COPY ./ $WWS_BUILD_DIR/
 RUN echo "Running on ${BUILDPLATFORM}, building for ${TARGETPLATFORM}"
-
-# Switch to nightly to avoid memory issues when pulling Crates.io
-# https://github.com/rust-lang/cargo/issues/10781
-RUN apt-get update && apt-get install -y musl musl-dev musl-tools
 RUN set -eux; \
     ls -l .; \
     case "${TARGETPLATFORM}" in \
-        linux/amd64) bldArch='x86_64-unknown-linux-musl' ;; \
-        linux/arm64) bldArch='aarch64-unknown-linux-musl' ;; \
+        linux/amd64) bldArch='x86_64-unknown-linux-gnu' ;; \
+        linux/arm64) bldArch='aarch64-unknown-linux-gnu' ;; \
         *) echo >&2 "unsupported architecture: $BUILDPLATFORM"; exit 1 ;; \
     esac; \
-    rustup default nightly; \
     rustup target add $bldArch; \
-    cargo +nightly build --release --target=$bldArch -Z sparse-registry; \
+    cargo build --release --target=$bldArch; \
     mkdir ./build; \
     cp ./target/$bldArch/release/wws ./build/wws
 
-# Build the final image
-FROM --platform=$TARGETPLATFORM scratch
-ARG WWS_BUILD_DIR=/usr/src/wws
-LABEL org.opencontainers.image.source=https://github.com/vmware-labs/wasm-workers-server
-LABEL org.opencontainers.image.description="Wasm Workers Server is a blazing-fast self-contained server that routes HTTP requests to workers in your filesystem. Everything run in a WebAssembly sandbox."
-LABEL org.opencontainers.image.licenses="Apache-2.0"
-COPY --from=build-wws ${WWS_BUILD_DIR}/build/wws /
 
-CMD ["/wws", "/app/", "--host", "0.0.0.0"]
+FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+ARG WWS_BUILD_DIR=/usr/src/wws
+RUN mkdir -p /app
+RUN mkdir -p /opt
+COPY --from=build-wws ${WWS_BUILD_DIR}/build/wws /opt
+
+CMD ["/opt/wws", "/app/", "--host", "0.0.0.0"]
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,31 +1,40 @@
-# Build wasm_runtime in release mode
-
-
-FROM --platform=$TARGETPLATFORM rust:1.64.0-slim as build-wws
+# Build Wasm Workers in release mode. This is a multiplatform
+# container, so we ensure we build it for amd64 and arm64.
+# This will require the Rust configuration to change when
+# building the project
+FROM --platform=$TARGETPLATFORM rust:1.65.0-slim as build-wws
 ARG WWS_BUILD_DIR=/usr/src/wws
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 WORKDIR $WWS_BUILD_DIR
-COPY ./ $WWS_BUILD_DIR/
+# Only copy required files
+COPY ./Cargo.* $WWS_BUILD_DIR/
+COPY ./src $WWS_BUILD_DIR/src
+COPY ./kits $WWS_BUILD_DIR/kits
 RUN echo "Running on ${BUILDPLATFORM}, building for ${TARGETPLATFORM}"
+
+# Switch to nightly to avoid memory issues when pulling Crates.io
+# https://github.com/rust-lang/cargo/issues/10781
 RUN set -eux; \
     ls -l .; \
     case "${TARGETPLATFORM}" in \
-        linux/amd64) bldArch='x86_64-unknown-linux-gnu' ;; \
-        linux/arm64) bldArch='aarch64-unknown-linux-gnu' ;; \
+        linux/amd64) bldArch='x86_64-unknown-linux-musl' ;; \
+        linux/arm64) bldArch='aarch64-unknown-linux-musl' ;; \
         *) echo >&2 "unsupported architecture: $BUILDPLATFORM"; exit 1 ;; \
     esac; \
+    rustup default nightly; \
     rustup target add $bldArch; \
-    cargo build --release --target=$bldArch; \
+    cargo +nightly build --release --target=$bldArch -Z sparse-registry; \
     mkdir ./build; \
     cp ./target/$bldArch/release/wws ./build/wws
 
-
-FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+# Build the final image
+FROM --platform=$TARGETPLATFORM scratch
 ARG WWS_BUILD_DIR=/usr/src/wws
-RUN mkdir -p /app
-RUN mkdir -p /opt
-COPY --from=build-wws ${WWS_BUILD_DIR}/build/wws /opt
+LABEL org.opencontainers.image.source=https://github.com/vmware-labs/wasm-workers-server
+LABEL org.opencontainers.image.description="Wasm Workers Server is a blazing-fast self-contained server that routes HTTP requests to workers in your filesystem. Everything run in a WebAssembly sandbox."
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+COPY --from=build-wws ${WWS_BUILD_DIR}/build/wws /
 
-CMD ["/opt/wws", "/app/", "--host", "0.0.0.0"]
+CMD ["/wws", "/app/", "--host", "0.0.0.0"]
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "Running on ${BUILDPLATFORM}, building for ${TARGETPLATFORM}"
 
 # Switch to nightly to avoid memory issues when pulling Crates.io
 # https://github.com/rust-lang/cargo/issues/10781
-RUN apt-get update && apt-get install -y musl
+RUN apt-get update && apt-get install -y musl musl-dev musl-tools
 RUN set -eux; \
     ls -l .; \
     case "${TARGETPLATFORM}" in \

--- a/image/Prebuilt.dockerfile
+++ b/image/Prebuilt.dockerfile
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.source=https://github.com/vmware-labs/wasm-worker
 LABEL org.opencontainers.image.description="Wasm Workers Server is a blazing-fast self-contained server that routes HTTP requests to workers in your filesystem. Everything run in a WebAssembly sandbox."
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-COPY ./wws-$TARGETARCH /
+COPY --chmod=755 ./wws-$TARGETARCH /wws
 
 CMD ["/wws", "/app/", "--host", "0.0.0.0"]
 

--- a/image/Prebuilt.dockerfile
+++ b/image/Prebuilt.dockerfile
@@ -2,6 +2,10 @@
 # is mainly used to build the preview / release container images in
 # GitHub actions
 
+# Dtermine the targets
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
 # Build the final image
 FROM --platform=$TARGETPLATFORM scratch
 LABEL org.opencontainers.image.source=https://github.com/vmware-labs/wasm-workers-server

--- a/image/Prebuilt.dockerfile
+++ b/image/Prebuilt.dockerfile
@@ -1,0 +1,14 @@
+# In this case, the binaries should be already created. This Dockerfile
+# is mainly used to build the preview / release container images in
+# GitHub actions
+
+# Build the final image
+FROM --platform=$TARGETPLATFORM scratch
+LABEL org.opencontainers.image.source=https://github.com/vmware-labs/wasm-workers-server
+LABEL org.opencontainers.image.description="Wasm Workers Server is a blazing-fast self-contained server that routes HTTP requests to workers in your filesystem. Everything run in a WebAssembly sandbox."
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+COPY ./wws-$TARGETARCH /
+
+CMD ["/wws", "/app/", "--host", "0.0.0.0"]
+

--- a/image/Prebuilt.dockerfile
+++ b/image/Prebuilt.dockerfile
@@ -2,12 +2,10 @@
 # is mainly used to build the preview / release container images in
 # GitHub actions
 
-# Dtermine the targets
-ARG TARGETPLATFORM
-ARG TARGETARCH
-
 # Build the final image
 FROM --platform=$TARGETPLATFORM scratch
+ARG TARGETPLATFORM
+ARG TARGETARCH
 LABEL org.opencontainers.image.source=https://github.com/vmware-labs/wasm-workers-server
 LABEL org.opencontainers.image.description="Wasm Workers Server is a blazing-fast self-contained server that routes HTTP requests to workers in your filesystem. Everything run in a WebAssembly sandbox."
 LABEL org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
Automate the creation of containers using GitHub Actions. This will push the images to the GitHub Package Registry. In addition to that, we are also trying to reduce the size of the produced images.

I created two different actions:

- Preview: runs on every commit in `main`
- Release: runs on every new vX.X.X tag

The code is duplicated, but I plan to refactor all actions and make some parts reusable in a separate PR.

Here you have the created package: https://github.com/vmware-labs/wasm-workers-server/pkgs/container/wws 

Closes #50 and #24 