### PR TITLE
Improve filesystem routing and path management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "brownstone"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5839ee4f953e811bfdcf223f509cb2c6a3e1447959b0bff459405575bc17f22"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +585,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7309d9b4d3d2c0641e018d449232f2e28f1b22933c137f157d3dbc14228b8c0e"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1141,6 +1181,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent_write"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1278,12 @@ checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "joinery"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "language-tags"
@@ -1418,6 +1470,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom-supreme"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd3ae6c901f1959588759ff51c95d24b491ecb9ff91aa9c2ef4acc5b1dcab27"
+dependencies = [
+ "brownstone",
+ "indent_write",
+ "joinery",
+ "memchr",
+ "nom",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,6 +1574,15 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1686,6 +1760,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -2134,6 +2214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,7 +2341,6 @@ dependencies = [
  "base64",
  "clap 4.0.32",
  "env_logger 0.9.3",
- "glob",
  "lazy_static",
  "regex",
  "serde",
@@ -2264,6 +2349,7 @@ dependencies = [
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
+ "wax",
 ]
 
 [[package]]
@@ -2514,6 +2600,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584aaf7a1ecf4d383bbe1a25eeab0cbb8ff96acc6796707ff65cde48f4632f15"
 dependencies = [
  "wast 50.0.0",
+]
+
+[[package]]
+name = "wax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c7a3bac6110ac062b7b422a442b7ee23e07209e2784a036654cab1e71bbafc"
+dependencies = [
+ "bstr",
+ "const_format",
+ "itertools",
+ "nom",
+ "nom-supreme",
+ "pori",
+ "regex",
+ "smallvec",
+ "thiserror",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
 env_logger = "0.9.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
-glob = "0.3.0"
+wax = "0.5.0"
 toml = "0.5.9"
 base64 = "0.13.1"
 clap = { version = "4.0.10", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate lazy_static;
 
 mod config;
 mod data;
-mod router;
+mod routing;
 mod runner;
 
 use actix_files::{Files, NamedFile};
@@ -19,7 +19,7 @@ use actix_web::{
 };
 use clap::Parser;
 use data::kv::KV;
-use router::Routes;
+use routing::router;
 use runner::WasmOutput;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
@@ -111,7 +111,7 @@ async fn find_static_html(uri_path: &str) -> Result<NamedFile, Error> {
 /// For these reasons, we are selecting the right handler at this point and not
 /// allowing Actix to select it for us.
 async fn wasm_handler(req: HttpRequest, body: Bytes) -> HttpResponse {
-    let routes = req.app_data::<Data<Routes>>().unwrap();
+    let routes = req.app_data::<Data<router::Routes>>().unwrap();
     let data_connectors = req
         .app_data::<Data<RwLock<DataConnectors>>>()
         .unwrap()
@@ -198,7 +198,7 @@ async fn wasm_handler(req: HttpRequest, body: Bytes) -> HttpResponse {
 }
 
 async fn debug(req: HttpRequest) -> impl Responder {
-    let value = req.app_data::<Data<Routes>>().unwrap();
+    let value = req.app_data::<Data<router::Routes>>().unwrap();
     HttpResponse::Ok().body(format!("Routes: {}", value.routes.len()))
 }
 
@@ -213,7 +213,7 @@ async fn main() -> std::io::Result<()> {
     let prefix = router::format_prefix(&args.prefix);
 
     println!("⚙️  Loading routes from: {}", &args.path.display());
-    let routes = Data::new(Routes {
+    let routes = Data::new(router::Routes {
         routes: router::initialize_routes(&args.path, &prefix),
     });
 

--- a/src/router/files.rs
+++ b/src/router/files.rs
@@ -1,0 +1,101 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
+use wax::{Glob, WalkEntry};
+
+/// Manages the files associated to a Wasm Workers Run.
+/// It uses glob patterns to detect the workers and
+/// provide utilities to work with public folders and
+/// other related resources.
+pub struct Files {
+    root: PathBuf,
+    has_public: bool,
+}
+
+impl Files {
+    /// Initializes a new files instance. It will detect
+    /// relevant resources for WWS like the public folder.
+    pub fn new(root: &Path) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            has_public: root.join(Path::new("public")).exists(),
+        }
+    }
+
+    /// Walk through all the different files associated to this
+    /// project using a Glob pattern
+    pub fn walk(&self) -> Vec<WalkEntry> {
+        let glob =
+            Glob::new("**/*.{wasm,js}").expect("Failed to read the files in the current directory");
+
+        glob.walk(&self.root)
+            .filter_map(|el| match el {
+                Ok(entry) if !self.is_in_public_folder(entry.path()) => Some(entry),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Checks if the given filepath is inside the "public" folder.
+    /// It will return an early false if the project doesn't have
+    /// a public folder.
+    pub fn is_in_public_folder(&self, path: &Path) -> bool {
+        if !self.has_public {
+            return false;
+        }
+
+        path.components().any(|c| match c {
+            Component::Normal(os_str) => os_str == OsStr::new("public"),
+            _ => false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn unix_is_in_public_folder() {
+        let tests = [
+            ("public/index.js", true),
+            ("examples/public/index.js", true),
+            ("examples/public/other.js", true),
+            ("public.js", false),
+            ("examples/public.js", false),
+            ("./examples/public.js", false),
+            ("./examples/index.js", false),
+        ];
+
+        for t in tests {
+            assert_eq!(
+                Files::new(Path::new("./tests/data")).is_in_public_folder(Path::new(t.0)),
+                t.1
+            )
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn win_is_in_public_folder() {
+        let tests = [
+            ("public\\index.js", true),
+            ("examples\\public\\index.js", true),
+            ("examples\\public\\other.js", true),
+            ("public.js", false),
+            ("examples\\public.js", false),
+            (".\\examples\\public.js", false),
+            (".\\examples\\index.js", false),
+        ];
+
+        for t in tests {
+            assert_eq!(
+                Files::new(Path::new(".\\tests\\data")).is_in_public_folder(Path::new(t.0)),
+                t.1
+            )
+        }
+    }
+}

--- a/src/router/files.rs
+++ b/src/router/files.rs
@@ -41,7 +41,7 @@ impl Files {
     /// Checks if the given filepath is inside the "public" folder.
     /// It will return an early false if the project doesn't have
     /// a public folder.
-    pub fn is_in_public_folder(&self, path: &Path) -> bool {
+    fn is_in_public_folder(&self, path: &Path) -> bool {
         if !self.has_public {
             return false;
         }

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,0 +1,9 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod files;
+pub mod route;
+pub mod routes;
+
+pub use route::Route;
+pub use routes::Routes;

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,9 +1,8 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod files;
-pub mod route;
-pub mod routes;
+mod files;
+mod route;
+mod routes;
 
-pub use route::Route;
-pub use routes::Routes;
+pub(crate) use routes::Routes;

--- a/src/router/route.rs
+++ b/src/router/route.rs
@@ -109,7 +109,7 @@ impl Route {
     // - Remove file extension
     // - Keep only "normal" components. Others like "." or "./" are ignored
     // - Remove "index" components
-    pub fn normalize_path_to_url(path: &Path) -> String {
+    fn normalize_path_to_url(path: &Path) -> String {
         path.with_extension("")
             .components()
             .filter_map(|c| match c {

--- a/src/router/routes.rs
+++ b/src/router/routes.rs
@@ -1,0 +1,203 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Declare the different routes for the project
+// based on the files in the given folder
+//
+use std::path::Path;
+
+use super::files::Files;
+use super::route::{Route, RouteAffinity};
+
+/// Contains all registered routes
+pub struct Routes {
+    pub routes: Vec<Route>,
+    pub prefix: String,
+}
+
+impl Routes {
+    /// Initialize the list of routes from the given folder. This method will look for
+    /// different files and will create the associated routes. This routing approach
+    /// is pretty popular in web development and static sites.
+    pub fn new(path: &Path, base_prefix: &str) -> Self {
+        let mut routes = Vec::new();
+        let prefix = Self::format_prefix(base_prefix);
+        let files = Files::new(path);
+
+        for entry in files.walk() {
+            routes.push(Route::new(path, entry.into_path(), &prefix));
+        }
+
+        Self { routes, prefix }
+    }
+
+    /// Based on a set of routes and a given path, it provides the best
+    /// match based on the parametrized URL score. See the [`Route::can_manage_path`]
+    /// method to understand how to calculate the score.
+    pub fn retrieve_best_route<'a>(&'a self, path: &str) -> Option<&'a Route> {
+        // Keep it to avoid calculating the score twice when iterating
+        // to look for the best route
+        let mut best_score = -1;
+
+        self.routes
+            .iter()
+            .fold(None, |acc, item| match item.affinity(path) {
+                RouteAffinity::CanManage(score) if best_score == -1 || score < best_score => {
+                    best_score = score;
+                    Some(item)
+                }
+                _ => acc,
+            })
+    }
+
+    /// Defines a prefix in the context of the application.
+    /// This prefix will be used for the static assets and the
+    /// workers.
+    ///
+    /// A prefix must have the format: /X. This method receives
+    /// the optional prefix and returns a proper String.
+    ///
+    /// To be flexible, the method will manage "windows" paths too:
+    /// \app. This shouldn't be considered as "prefix" must be an URI
+    /// path. However, the check is pretty simple, so we will consider
+    /// it.
+    fn format_prefix(source: &str) -> String {
+        let mut normalized_prefix = source.to_string();
+        // Ensure the prefix doesn't include any \ character
+        normalized_prefix = normalized_prefix.replace('\\', "/");
+
+        if normalized_prefix.is_empty() {
+            normalized_prefix
+        } else {
+            if !normalized_prefix.starts_with('/') {
+                normalized_prefix = String::from('/') + &normalized_prefix;
+            }
+
+            if normalized_prefix.ends_with('/') {
+                normalized_prefix.pop();
+            }
+
+            normalized_prefix
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn route_path_affinity() {
+        let build_route = |file: &str| -> Route {
+            Route::new(
+                Path::new("./tests/data/params"),
+                PathBuf::from(format!("./tests/data/params{}", file)),
+                "",
+            )
+        };
+
+        // Route initializes the Wasm module. We create these
+        // variables to avoid loading the same Wasm module multiple times
+        let param_route = build_route("/[id].wasm");
+        let fixed_route = build_route("/fixed.wasm");
+        let param_folder_route = build_route("/[id]/fixed.wasm");
+        let param_sub_route = build_route("/sub/[id].wasm");
+
+        let tests = [
+            (&param_route, "/a", RouteAffinity::CanManage(1)),
+            (&fixed_route, "/fixed", RouteAffinity::CanManage(0)),
+            (&fixed_route, "/a", RouteAffinity::CannotManage),
+            (&param_folder_route, "/a", RouteAffinity::CannotManage),
+            (&param_folder_route, "/a/fixed", RouteAffinity::CanManage(1)),
+            (&param_sub_route, "/a/b", RouteAffinity::CannotManage),
+            (&param_sub_route, "/sub/b", RouteAffinity::CanManage(2)),
+        ];
+
+        for t in tests {
+            assert_eq!(t.0.affinity(t.1), t.2);
+        }
+    }
+
+    #[test]
+    fn best_route_by_affinity() {
+        let build_route = |file: &str| -> Route {
+            Route::new(
+                Path::new("./tests/data/params"),
+                PathBuf::from(format!("./tests/data/params{}", file)),
+                "",
+            )
+        };
+
+        // Route initializes the Wasm module. We create these
+        // variables to avoid loading the same Wasm module multiple times
+        let param_route = build_route("/[id].wasm");
+        let fixed_route = build_route("/fixed.wasm");
+        let param_folder_route = build_route("/[id]/fixed.wasm");
+        let param_sub_route = build_route("/sub/[id].wasm");
+
+        // I'm gonna use this values for comparison as `routes` consumes
+        // the Route elements.
+        let param_path = param_route.path.clone();
+        let fixed_path = fixed_route.path.clone();
+        let param_folder_path = param_folder_route.path.clone();
+        let param_sub_path = param_sub_route.path.clone();
+
+        let routes = Routes {
+            routes: vec![
+                param_route,
+                fixed_route,
+                param_folder_route,
+                param_sub_route,
+            ],
+            prefix: String::from("/"),
+        };
+
+        let tests = [
+            ("/a", Some(param_path)),
+            ("/fixed", Some(fixed_path)),
+            ("/a/fixed", Some(param_folder_path)),
+            ("/sub/b", Some(param_sub_path)),
+            ("/donot/exist", None),
+        ];
+
+        for t in tests {
+            let route = routes.retrieve_best_route(t.0);
+
+            if let Some(path) = t.1 {
+                assert!(route.is_some());
+                assert_eq!(route.unwrap().path, path);
+            } else {
+                assert!(route.is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn format_provided_prefix() {
+        let tests = [
+            // Unix approach
+            ("", ""),
+            ("/app", "/app"),
+            ("app", "/app"),
+            ("app/", "/app"),
+            ("/app/", "/app"),
+            ("/app/test/", "/app/test"),
+            ("/app/test", "/app/test"),
+            ("app/test/", "/app/test"),
+            // Windows approach
+            ("\\app", "/app"),
+            ("app", "/app"),
+            ("app\\", "/app"),
+            ("\\app\\", "/app"),
+            ("\\app\\test\\", "/app/test"),
+            ("\\app\\test", "/app/test"),
+            ("app\\test\\", "/app/test"),
+        ];
+
+        for t in tests {
+            assert_eq!(Routes::format_prefix(t.0), String::from(t.1))
+        }
+    }
+}

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,4 +1,0 @@
-// Copyright 2022 VMware, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-pub mod router;

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,0 +1,4 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod router;


### PR DESCRIPTION
Refactor the logic to load the app routes from the filesystem. Before, we were using functions instead of related struct implementations. The code was not clear and `structs` were taking mixed responsibilities. For example, we had a public function to `retrieve_best_route` that takes `Routes` as a parameter. I converted this into a `Routes`'s method directly.

This is the list of changes I applied:

- Create a separate folder for the filesystem routing logic (`router`)
- Split `Routes` and `Route` structs into separate files
- Move public functions to `struct` implementations to avoid passing references around to provide a result
- Replace `glob` library with `wax`. This library provides a better support for glob patterns. For example, `glob` doesn't support multiple options like `*.{js,wasm}`
- Update the `main` entrypoint to use the new APIs. It didn't require many changes.

It closes #3