### PR TITLE
feat: add the runtimes command to manage language runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
  "http",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.5",
  "language-tags",
  "local-channel",
  "mime",
@@ -176,7 +176,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "itoa",
+ "itoa 1.0.5",
  "language-tags",
  "log",
  "mime",
@@ -442,6 +442,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -875,6 +876,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa 0.4.8",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +950,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +986,12 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1249,7 +1288,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 1.0.5",
 ]
 
 [[package]]
@@ -1302,7 +1341,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.5",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1406,6 +1445,12 @@ checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
@@ -1851,6 +1896,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettytable-rs"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
+dependencies = [
+ "csv",
+ "encode_unicode",
+ "is-terminal",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,12 +2168,18 @@ dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
- "itoa",
+ "itoa 1.0.5",
  "libc",
  "linux-raw-sys",
  "once_cell",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
@@ -2210,7 +2275,7 @@ version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -2231,7 +2296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -2408,6 +2473,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,7 +2527,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa",
+ "itoa 1.0.5",
  "serde",
  "time-core",
  "time-macros",
@@ -2872,6 +2948,7 @@ dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
  "openssl",
+ "prettytable-rs",
  "regex",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ regex = "1"
 url = "2.3.1"
 reqwest = { version = "0.11" }
 sha256 = "1.1.1"
+prettytable-rs = "0.10.0"
 
 [target.x86_64-unknown-linux-musl.dependencies]
 openssl = { version = "=0.10.45", features = ["vendored"] }

--- a/src/commands/main.rs
+++ b/src/commands/main.rs
@@ -1,0 +1,12 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::runtimes::Runtimes;
+use clap::Subcommand;
+
+/// Available subcommands in the CLI
+#[derive(Subcommand, Debug)]
+pub enum Main {
+    #[clap(name = "runtimes")]
+    Runtimes(Runtimes),
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// The different commands for the `wws` CLI.
+pub(crate) mod main;
+pub(crate) mod runtimes;

--- a/src/commands/runtimes.rs
+++ b/src/commands/runtimes.rs
@@ -18,7 +18,7 @@ use std::env;
 /// Default repository name
 pub const DEFAULT_REPO_NAME: &str = "wlr";
 /// Default repository URL
-pub const DEFAULT_REPO_URL: &str = "https://languages.wasmlabs.dev/repository/v1/index.toml";
+pub const DEFAULT_REPO_URL: &str = "https://assets.wasmlabs.dev/repository/v1/index.toml";
 
 /// Environment variable to set the repository name
 pub const WWS_REPO_NAME: &str = "WWS_REPO_NAME";

--- a/src/commands/runtimes.rs
+++ b/src/commands/runtimes.rs
@@ -16,11 +16,8 @@ use prettytable::{format, Cell, Row, Table};
 
 /// Default repository name
 pub const DEFAULT_REPO_NAME: &str = "wlr";
-// TODO (Angelmmiguel): update it to point to an index file generated on the
-// WebAssembly Languages Runtime repo.
 /// Default repository URL
-pub const DEFAULT_REPO_URL: &str =
-    "https://raw.githubusercontent.com/Angelmmiguel/wws-index-test/main/index.toml";
+pub const DEFAULT_REPO_URL: &str = "https://languages.wasmlabs.dev/repository/v1/index.toml";
 
 /// Manage the language runtimes in your project
 #[derive(Parser, Debug)]

--- a/src/commands/runtimes.rs
+++ b/src/commands/runtimes.rs
@@ -13,11 +13,16 @@ use crate::{
 use anyhow::{anyhow, Result};
 use clap::{Args, Parser, Subcommand};
 use prettytable::{format, Cell, Row, Table};
+use std::env;
 
 /// Default repository name
 pub const DEFAULT_REPO_NAME: &str = "wlr";
 /// Default repository URL
 pub const DEFAULT_REPO_URL: &str = "https://languages.wasmlabs.dev/repository/v1/index.toml";
+
+/// Environment variable to set the repository name
+pub const WWS_REPO_NAME: &str = "WWS_REPO_NAME";
+pub const WWS_REPO_URL: &str = "WWS_REPO_URL";
 
 /// Manage the language runtimes in your project
 #[derive(Parser, Debug)]
@@ -93,7 +98,7 @@ impl Install {
 
                 // Update the configuration
                 let mut config = Config::load(project_root)?;
-                config.save_runtime(&repo_name, runtime);
+                config.save_runtime(&repo_name, &repo_url, runtime);
                 config.save(project_root)?;
 
                 println!("✅ Done");
@@ -254,7 +259,7 @@ impl Uninstall {
 
         if let Some(runtime) = runtime {
             println!(
-                "🗑 Uninstalling: {} - {} / {}",
+                "🗑  Uninstalling: {} - {} / {}",
                 &repo_name, &runtime.name, &runtime.version
             );
             uninstall_runtime(project_root, &repo_name, runtime)?;
@@ -262,7 +267,7 @@ impl Uninstall {
             config.save(project_root)?;
         } else {
             println!(
-                "🗑 The runtime was not installed: {} - {} / {}",
+                "🗑  The runtime was not installed: {} - {} / {}",
                 &repo_name, &self.name, &self.version
             );
         }
@@ -275,7 +280,7 @@ impl Uninstall {
 /// Utility to retrieve the repository name for the given command.
 /// It will look first for the flag and fallback to the default value.
 fn get_repo_name(args: &Runtimes) -> String {
-    let default_value = DEFAULT_REPO_NAME.into();
+    let default_value = env::var(WWS_REPO_NAME).unwrap_or_else(|_| DEFAULT_REPO_NAME.into());
     args.repo_name
         .as_ref()
         .unwrap_or(&default_value)
@@ -285,6 +290,6 @@ fn get_repo_name(args: &Runtimes) -> String {
 /// Utility to retrieve the repository url for the given command.
 /// It will look first for the flag and fallback to the default value.
 fn get_repo_url(args: &Runtimes) -> String {
-    let default_value = DEFAULT_REPO_URL.into();
+    let default_value = env::var(WWS_REPO_URL).unwrap_or_else(|_| DEFAULT_REPO_URL.into());
     args.repo_url.as_ref().unwrap_or(&default_value).to_string()
 }

--- a/src/commands/runtimes.rs
+++ b/src/commands/runtimes.rs
@@ -1,0 +1,293 @@
+// Copyright 2022 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+use crate::{
+    config::Config,
+    runtimes::{
+        manager::{check_runtime, install_runtime, uninstall_runtime},
+        metadata::Repository,
+    },
+};
+use anyhow::{anyhow, Result};
+use clap::{Args, Parser, Subcommand};
+use prettytable::{format, Cell, Row, Table};
+
+/// Default repository name
+pub const DEFAULT_REPO_NAME: &str = "wlr";
+// TODO (Angelmmiguel): update it to point to an index file generated on the
+// WebAssembly Languages Runtime repo.
+/// Default repository URL
+pub const DEFAULT_REPO_URL: &str =
+    "https://raw.githubusercontent.com/Angelmmiguel/wws-index-test/main/index.toml";
+
+/// Manage the language runtimes in your project
+#[derive(Parser, Debug)]
+pub struct Runtimes {
+    /// Set a different repository URL
+    #[arg(long)]
+    repo_url: Option<String>,
+    /// Gives a name to the given repository URL
+    #[arg(long)]
+    repo_name: Option<String>,
+
+    #[command(subcommand)]
+    pub runtime_commands: RuntimesCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RuntimesCommands {
+    Install(Install),
+    List(List),
+    Check(Check),
+    Uninstall(Uninstall),
+}
+
+/// Install a new language runtime (like Ruby, Python, etc)
+#[derive(Args, Debug)]
+pub struct Install {
+    /// Name of the desired runtime
+    pub name: Option<String>,
+    /// Version of the desired runtime
+    pub version: Option<String>,
+}
+
+impl Install {
+    /// Install the given runtime to the project. It will look for
+    /// the runtimes in the defined repository
+    pub async fn run(&self, project_root: &Path, args: &Runtimes) -> Result<()> {
+        match (&self.name, &self.version) {
+            (Some(name), Some(version)) => {
+                self.install_from_repository(project_root, args, name, version)
+                    .await
+            }
+            (Some(_), None) | (None, Some(_)) => Err(anyhow!(
+                "The name and version are mandatory when installing a runtime from a repository"
+            )),
+            (None, None) => self.install_missing_runtimes(project_root).await,
+        }
+    }
+
+    /// Retrieves the remote repository and install the desired runtime.
+    /// It will return an error if the desired runtime is not present in
+    /// the repo.
+    async fn install_from_repository(
+        &self,
+        project_root: &Path,
+        args: &Runtimes,
+        name: &str,
+        version: &str,
+    ) -> Result<()> {
+        let repo_name = get_repo_name(args);
+        let repo_url = get_repo_url(args);
+
+        println!("⚙️  Fetching data from the repository...");
+        let repo = Repository::from_remote_file(&repo_url).await?;
+        let runtime = repo.find_runtime(name, version);
+
+        if let Some(runtime) = runtime {
+            if check_runtime(project_root, &repo_name, runtime) {
+                println!("✅ The runtime is already installed");
+                Ok(())
+            } else {
+                println!("🚀 Installing the runtime...");
+                install_runtime(project_root, &repo_name, runtime).await?;
+
+                // Update the configuration
+                let mut config = Config::load(project_root)?;
+                config.save_runtime(&repo_name, runtime);
+                config.save(project_root)?;
+
+                println!("✅ Done");
+                Ok(())
+            }
+        } else {
+            Err(anyhow!(
+                "The runtime with name = '{}' and version = '{}' is not present in the repository",
+                name,
+                version
+            ))
+        }
+    }
+
+    /// Loads the local configuration and install any missing runtime from it.
+    /// It will check all the different repositories and install missing
+    /// runtimes inside them.
+    async fn install_missing_runtimes(&self, project_root: &Path) -> Result<()> {
+        println!("⚙️  Checking local configuration...");
+        // Retrieve the configuration
+        let config = Config::load(project_root)?;
+
+        for repo in &config.repositories {
+            for runtime in &repo.runtimes {
+                let is_installed = check_runtime(project_root, &repo.name, runtime);
+
+                if !is_installed {
+                    println!(
+                        "🚀 Installing: {} - {} / {}",
+                        &repo.name, &runtime.name, &runtime.version
+                    );
+                    install_runtime(project_root, &repo.name, runtime).await?;
+                }
+            }
+        }
+
+        println!("✅ Done");
+        Ok(())
+    }
+}
+
+/// List all available runtimes to install. By default, it uses the WebAssembly
+/// Language Runtime repository
+#[derive(Args, Debug)]
+pub struct List {}
+
+impl List {
+    /// Retrieve the list of runtimes from the remote repository and
+    /// show it as a list
+    pub async fn run(&self, args: &Runtimes) -> Result<()> {
+        let repo_url = get_repo_url(args);
+
+        println!("⚙️  Fetching data from the repository...");
+        let repo = Repository::from_remote_file(&repo_url).await?;
+
+        let mut table = Table::new();
+        table.set_format(*format::consts::FORMAT_BOX_CHARS);
+
+        table.add_row(Row::new(vec![
+            Cell::new("Name"),
+            Cell::new("Version"),
+            Cell::new("Extension"),
+            Cell::new("Binary"),
+        ]));
+
+        for runtime in &repo.runtimes {
+            table.add_row(Row::new(vec![
+                Cell::new(&runtime.name),
+                Cell::new(&runtime.version),
+                Cell::new(&runtime.extensions.join(", ")),
+                Cell::new(&runtime.binary.filename),
+            ]));
+        }
+
+        table.printstd();
+
+        Ok(())
+    }
+}
+
+/// List of locally installed runtimes
+#[derive(Args, Debug)]
+pub struct Check {}
+
+impl Check {
+    /// Displays the .wws.toml file dependencies and checks if they are
+    /// installed in the current project root.
+    pub fn run(&self, project_root: &Path) -> Result<()> {
+        // Retrieve the configuration
+        let config = Config::load(project_root)?;
+        let mut is_missing = false;
+        let mut total = 0;
+
+        let mut table = Table::new();
+        table.set_format(*format::consts::FORMAT_BOX_CHARS);
+
+        table.add_row(Row::new(vec![
+            Cell::new("Installed"),
+            Cell::new("Name"),
+            Cell::new("Version"),
+            Cell::new("Extension"),
+            Cell::new("Binary"),
+        ]));
+
+        for repo in &config.repositories {
+            for runtime in &repo.runtimes {
+                let is_installed = check_runtime(project_root, &repo.name, runtime);
+
+                if !is_installed {
+                    is_missing = true;
+                }
+
+                table.add_row(Row::new(vec![
+                    Cell::new(if is_installed { "✅" } else { "❌" }),
+                    Cell::new(&runtime.name),
+                    Cell::new(&runtime.version),
+                    Cell::new(&runtime.extensions.join(", ")),
+                    Cell::new(&runtime.binary.filename),
+                ]));
+
+                total += 1;
+            }
+        }
+
+        table.printstd();
+
+        // Provide a hint
+        if is_missing {
+            println!("\n💡 Tip: there are missing language runtimes. You can install them with `wws runtimes install`");
+        }
+
+        if total == 0 {
+            println!("\n💡 Tip: you can check the available language runtimes by running `wws runtimes list`");
+        }
+
+        Ok(())
+    }
+}
+
+/// Uninstall a language runtime
+#[derive(Args, Debug)]
+pub struct Uninstall {
+    /// Name of the desired runtime
+    name: String,
+    /// Version of the desired runtime
+    version: String,
+}
+
+impl Uninstall {
+    /// Uninstall the given runtime from the local system. This will
+    /// remove the files from the `.wws` folder and the runtime metadata
+    /// from the .wws.toml file
+    pub fn run(&self, project_root: &Path, args: &Runtimes) -> Result<()> {
+        // Retrieve the configuration
+        let mut config = Config::load(project_root)?;
+        let repo_name = get_repo_name(args);
+        let runtime = config.get_runtime(&repo_name, &self.name, &self.version);
+
+        if let Some(runtime) = runtime {
+            println!(
+                "🗑 Uninstalling: {} - {} / {}",
+                &repo_name, &runtime.name, &runtime.version
+            );
+            uninstall_runtime(project_root, &repo_name, runtime)?;
+            config.remove_runtime(&repo_name, &self.name, &self.version);
+            config.save(project_root)?;
+        } else {
+            println!(
+                "🗑 The runtime was not installed: {} - {} / {}",
+                &repo_name, &self.name, &self.version
+            );
+        }
+
+        println!("✅ Done");
+        Ok(())
+    }
+}
+
+/// Utility to retrieve the repository name for the given command.
+/// It will look first for the flag and fallback to the default value.
+fn get_repo_name(args: &Runtimes) -> String {
+    let default_value = DEFAULT_REPO_NAME.into();
+    args.repo_name
+        .as_ref()
+        .unwrap_or(&default_value)
+        .to_string()
+}
+
+/// Utility to retrieve the repository url for the given command.
+/// It will look first for the flag and fallback to the default value.
+fn get_repo_url(args: &Runtimes) -> String {
+    let default_value = DEFAULT_REPO_URL.into();
+    args.repo_url.as_ref().unwrap_or(&default_value).to_string()
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,11 +27,9 @@ pub struct Config {
     /// Version of the .wws file
     version: u32,
     /// List of repositories
-    repositories: Vec<ConfigRepository>,
+    pub repositories: Vec<ConfigRepository>,
 }
 
-// TODO: Remove it when start adding the new subcommands
-#[allow(dead_code)]
 impl Config {
     /// Load the config file if it's present. It not, it will create a
     /// new empty config.
@@ -74,13 +72,27 @@ impl Config {
     }
 
     /// Remove an existing runtime if it's present.
-    pub fn remove_runtime(&mut self, repository: &str, runtime: &Runtime) {
+    pub fn remove_runtime(&mut self, repository: &str, name: &str, version: &str) {
         let repo = self.repositories.iter_mut().find(|r| r.name == repository);
 
         // Shadow to init an empty one if required
         if let Some(repo) = repo {
-            repo.runtimes.retain(|r| r != runtime);
+            repo.runtimes
+                .retain(|r| r.name != name && r.version != version);
         };
+    }
+
+    /// Get a given runtime from the current configuration if it's available.
+    pub fn get_runtime(&self, repository: &str, name: &str, version: &str) -> Option<&Runtime> {
+        let repo = self.repositories.iter().find(|r| r.name == repository);
+
+        if let Some(repo) = repo {
+            repo.runtimes
+                .iter()
+                .find(|r| r.name == name && r.version == version)
+        } else {
+            None
+        }
     }
 
     /// Write the current configuration into the `.wws.toml` file. It will
@@ -102,7 +114,7 @@ impl Config {
 pub struct ConfigRepository {
     /// Local name to identify the repository. It avoids collisions when installing
     /// language runtimes
-    name: String,
+    pub name: String,
     /// Installed runtimes
-    runtimes: Vec<Runtime>,
+    pub runtimes: Vec<Runtime>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,10 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::runtimes::metadata::Runtime;
+use crate::{
+    commands::runtimes::{DEFAULT_REPO_NAME, DEFAULT_REPO_URL},
+    runtimes::metadata::Runtime,
+};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -42,7 +45,8 @@ impl Config {
             })
         } else {
             let new_repo = ConfigRepository {
-                name: "wlr".to_string(),
+                name: DEFAULT_REPO_NAME.to_string(),
+                url: DEFAULT_REPO_URL.to_string(),
                 runtimes: Vec::new(),
             };
 
@@ -54,15 +58,16 @@ impl Config {
     }
 
     /// Save a new installed runtime
-    pub fn save_runtime(&mut self, repository: &str, runtime: &Runtime) {
-        let repo = self.repositories.iter_mut().find(|r| r.name == repository);
+    pub fn save_runtime(&mut self, repo_name: &str, repo_url: &str, runtime: &Runtime) {
+        let repo = self.repositories.iter_mut().find(|r| r.name == repo_name);
 
         // Shadow to init an empty one if required
         match repo {
             Some(r) => r.runtimes.push(runtime.clone()),
             None => {
                 let new_repo = ConfigRepository {
-                    name: repository.to_string(),
+                    name: repo_name.to_string(),
+                    url: repo_url.to_string(),
                     runtimes: vec![runtime.clone()],
                 };
 
@@ -115,6 +120,8 @@ pub struct ConfigRepository {
     /// Local name to identify the repository. It avoids collisions when installing
     /// language runtimes
     pub name: String,
+    /// Set the url from which this repository was downloaded
+    url: String,
     /// Installed runtimes
     pub runtimes: Vec<Runtime>,
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -3,13 +3,27 @@
 
 use crate::runtimes::metadata::Checksum;
 use anyhow::Result;
+use reqwest::header::USER_AGENT;
+
+/// The current wws version
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // TODO: Remove it when implementing the manager
 #[allow(dead_code)]
 /// Fetch the contents of a given file and validates it
 /// using the Sha256.
 pub async fn fetch<T: AsRef<str>>(file: T) -> Result<Vec<u8>> {
-    let body: Vec<u8> = reqwest::get(file.as_ref()).await?.bytes().await?.into();
+    let client = reqwest::Client::new();
+    let user_agent_value = format!("Wasm Workers Server/{}", VERSION);
+
+    let body: Vec<u8> = client
+        .get(file.as_ref())
+        .header(USER_AGENT, user_agent_value)
+        .send()
+        .await?
+        .bytes()
+        .await?
+        .into();
 
     Ok(body)
 }

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -8,8 +8,6 @@ use reqwest::header::USER_AGENT;
 /// The current wws version
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-// TODO: Remove it when implementing the manager
-#[allow(dead_code)]
 /// Fetch the contents of a given file and validates it
 /// using the Sha256.
 pub async fn fetch<T: AsRef<str>>(file: T) -> Result<Vec<u8>> {
@@ -28,8 +26,6 @@ pub async fn fetch<T: AsRef<str>>(file: T) -> Result<Vec<u8>> {
     Ok(body)
 }
 
-// TODO: Remove it when implementing the manager
-#[allow(dead_code)]
 /// Fetch the contents of a given file and validates it
 /// using the Sha256.
 pub async fn fetch_and_validate<T: AsRef<str>>(file: T, checksum: &Checksum) -> Result<Vec<u8>> {

--- a/src/runtimes/manager.rs
+++ b/src/runtimes/manager.rs
@@ -99,15 +99,12 @@ pub fn uninstall_runtime(
     repository: &str,
     metadata: &RuntimeMetadata,
 ) -> Result<()> {
-    let store = Store::new(
+    // Delete the current folder
+    Store::new(
         project_root,
         &["runtimes", repository, &metadata.name, &metadata.version],
-    );
-
-    // Delete the current folder
-    store.delete_root_folder()?;
-
-    Ok(())
+    )
+    .delete_root_folder()
 }
 
 /// Downloads a remote file in the given [Store].

--- a/src/runtimes/manager.rs
+++ b/src/runtimes/manager.rs
@@ -76,16 +76,21 @@ pub fn check_runtime(project_root: &Path, repository: &str, runtime: &RuntimeMet
     let binary = store.check_file(&[&runtime.binary.filename]);
     let mut template = true;
     let mut polyfill = true;
+    let mut wrapper = true;
 
     if let Some(template_file) = &runtime.template {
         template = store.check_file(&[&template_file.filename]);
+    }
+
+    if let Some(wrapper_file) = &runtime.wrapper {
+        wrapper = store.check_file(&[&wrapper_file.filename]);
     }
 
     if let Some(polyfill_file) = &runtime.polyfill {
         polyfill = store.check_file(&[&polyfill_file.filename]);
     }
 
-    binary && template && polyfill
+    binary && template && polyfill && wrapper
 }
 
 // Install a given runtime based on its metadata

--- a/src/runtimes/manager.rs
+++ b/src/runtimes/manager.rs
@@ -53,6 +53,10 @@ pub async fn install_runtime(
         download_file(polyfill, &store).await?;
     }
 
+    if let Some(wrapper) = &metadata.wrapper {
+        download_file(wrapper, &store).await?;
+    }
+
     if let Some(template) = &metadata.template {
         download_file(template, &store).await?;
     }

--- a/src/runtimes/metadata.rs
+++ b/src/runtimes/metadata.rs
@@ -8,6 +8,9 @@ use sha256::digest as sha256_digest;
 use std::collections::HashMap;
 use url::Url;
 
+/// Identify the current max repository version this build can manage.
+const MAX_REPOSITORY_VERSION: u32 = 1;
+
 /// A Repository contains the list of runtimes available on it.
 /// This file is used by wws to properly show the list of available
 /// repos and install them.
@@ -19,12 +22,15 @@ use url::Url;
 pub struct Repository {
     /// Version of the repository file
     pub version: u32,
-    /// The list of runtimes available in the repository
+    /// The list of runtimes available in the repository. By default, it will be
+    /// filled with an empty vector. The goal is to keep this repository
+    /// compatible with future changes. If we don't add this value and change the
+    /// runtimes key to something else in the future, the CLI won't deserialize
+    /// the version.
+    #[serde(default)]
     pub runtimes: Vec<Runtime>,
 }
 
-// TODO: Remove it when implementing the manager
-#[allow(dead_code)]
 impl Repository {
     /// Reads and parses the metadata from a slice of bytes. It will return
     /// a result as the deserialization may fail.
@@ -42,7 +48,17 @@ impl Repository {
         let data = fetch(&url).await?;
         let str_data = String::from_utf8(data)?;
 
-        Repository::from_str(&str_data)
+        let repo = Repository::from_str(&str_data)?;
+
+        if repo.version > MAX_REPOSITORY_VERSION {
+            println!(
+                "⚠️  The repository index version ({}) is not supported by your wws installation.",
+                repo.version
+            );
+            println!("⚠️  This may cause unexpected or missing behaviors. Please, update wws and try it again");
+        }
+
+        Ok(repo)
     }
 
     pub fn find_runtime(&self, name: &str, version: &str) -> Option<&Runtime> {
@@ -52,8 +68,6 @@ impl Repository {
     }
 }
 
-// TODO: Remove it when implementing the manager
-#[allow(dead_code)]
 /// Metadata associated to a Runtime. It contains information
 /// about a certain runtime like name, version and all the
 /// details to run workers with it.

--- a/src/runtimes/metadata.rs
+++ b/src/runtimes/metadata.rs
@@ -95,9 +95,12 @@ pub struct Runtime {
     pub binary: RemoteFile,
     /// The reference to a remote polyfill file (url + checksum)
     pub polyfill: Option<RemoteFile>,
-    /// The reference to a template file for the worker. It will wrap the
+    /// The reference to a wrapper file for the worker. It will wrap the
     /// source code into a template that can include imports,
     /// function calls, etc.
+    pub wrapper: Option<RemoteFile>,
+    /// The reference to an example file of a functional worker for this
+    /// runtime. It will be used to quickly bootstrap new workers.
     pub template: Option<RemoteFile>,
 }
 

--- a/src/runtimes/metadata.rs
+++ b/src/runtimes/metadata.rs
@@ -44,6 +44,12 @@ impl Repository {
 
         Repository::from_str(&str_data)
     }
+
+    pub fn find_runtime(&self, name: &str, version: &str) -> Option<&Runtime> {
+        self.runtimes
+            .iter()
+            .find(|r| r.name == name && r.version == version)
+    }
 }
 
 // TODO: Remove it when implementing the manager

--- a/src/runtimes/modules/javascript.rs
+++ b/src/runtimes/modules/javascript.rs
@@ -27,7 +27,7 @@ impl JavaScriptRuntime {
     /// this purpose
     pub fn new(project_root: &Path, path: PathBuf) -> Result<Self> {
         let hash = Store::file_hash(&path)?;
-        let store = Store::new(project_root, &["workers", "js", &hash])?;
+        let store = Store::create(project_root, &["workers", "js", &hash])?;
 
         Ok(Self { path, store })
     }

--- a/src/store.rs
+++ b/src/store.rs
@@ -31,8 +31,6 @@ pub struct Store {
     pub folder: PathBuf,
 }
 
-// TODO: Remove it when implementing the full logic
-#[allow(dead_code)]
 impl Store {
     /// Instance a new store. If you want to create the root folder, check [#create].
     /// The root path is used to scope the files inside the STORE_FOLDER folder. Note
@@ -55,6 +53,7 @@ impl Store {
     }
 
     /// Create the root folder for the current context
+    #[allow(dead_code)]
     pub fn create_root_folder(&self) -> Result<()> {
         fs::create_dir_all(&self.folder)
             .map_err(|err| anyhow!("There was an error creating the a required folder: {}", err))


### PR DESCRIPTION
After implementing the logic to retrieve, parse and manage language runtimes and repositories (see #63), this PR introduces the interface for developers to use it. The new `runtimes` command (the name is still under discussion and we may change it before v1.0.0) includes the following subcommands:

* `list`: reads a remote repository and shows the available language runtimes in a table
* `install`: install the desired runtime/s in the current project. Depending on the arguments provided, it will apply the following changes:
  * `<name> <version>`: load the remote repository and install the runtime locally. It will fetch the different files and edit  the `.wws.toml` file to reflect the new runtime
  * No arguments: it loads the `.wws.toml` file and install the missing runtimes in the local project
* `check`: load the `.wws.toml` file and checks if the required runtimes are installed locally
* `uninstall`: remove all the local files related to a runtime and edit the `.wws.toml` file to remove that dependency.

All these commands will use by default the [WebAssembly Language Runtimes](vmware-labs/webassembly-language-runtimes) project as the target repository. The `index.toml` files will be deployed as a static site and they will live in that repository.

If you want to use a different repository for listing and installing, you can set the `--repo-name` and `--repo-url` flags or set the `WWS_REPO_NAME` and `WWS_REPO_URL` environment variables:

```
export WWS_REPO_NAME=angel
export WWS_REPO_URL=https://raw.githubusercontent.com/Angelmmiguel/wws-index-test/main/index.toml
wws runtimes list
# or
wws runtimes --repo-name=repo --repo-url=https://raw.githubusercontent.com/Angelmmiguel/wws-index-test/main/index.toml list
```

After installing a runtime, `wws` stores all the metadata. Any other developer that installs the runtime will download the files from the right repository.

## Examples

```
$ export WWS_REPO_NAME=angel
$ export WWS_REPO_URL=https://raw.githubusercontent.com/Angelmmiguel/wws-index-test/main/index.toml
$ ./wws runtimes check
┌───────────┬──────┬─────────┬───────────┬────────┐
│ Installed │ Name │ Version │ Extension │ Binary │
└───────────┴──────┴─────────┴───────────┴────────┘

💡 Tip: you can check the available language runtimes by running `wws runtimes list`
$ ./wws runtimes list
⚙️  Fetching data from the repository...
┌──────┬────────────────────────┬───────────┬───────────┐
│ Name │ Version                │ Extension │ Binary    │
├──────┼────────────────────────┼───────────┼───────────┤
│ ruby │ 3.2.0+20230118-8aec06d │ rb        │ ruby.wasm │
└──────┴────────────────────────┴───────────┴───────────┘
$ ./wws runtimes install ruby 3.2.0+20230118-8aec06d
⚙️  Fetching data from the repository...
🚀 Installing the runtime...
✅ Done
$ ./wws runtimes check
┌───────────┬──────┬────────────────────────┬───────────┬───────────┐
│ Installed │ Name │ Version                │ Extension │ Binary    │
├───────────┼──────┼────────────────────────┼───────────┼───────────┤
│ ✅        │ ruby │ 3.2.0+20230118-8aec06d │ rb        │ ruby.wasm │
└───────────┴──────┴────────────────────────┴───────────┴───────────┘
$ ./wws runtimes uninstall ruby 3.2.0+20230118-8aec06d
🗑 Uninstalling: angel - ruby / 3.2.0+20230118-8aec06d
✅ Done
$ ./wws runtimes check
┌───────────┬──────┬─────────┬───────────┬────────┐
│ Installed │ Name │ Version │ Extension │ Binary │
└───────────┴──────┴─────────┴───────────┴────────┘

💡 Tip: you can check the available language runtimes by running `wws runtimes list`
```

It closes #68 