### PR TITLE
fix: use inline args in all println and format

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -12,7 +12,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// using the Sha256.
 pub async fn fetch<T: AsRef<str>>(file: T) -> Result<Vec<u8>> {
     let client = reqwest::Client::new();
-    let user_agent_value = format!("Wasm Workers Server/{}", VERSION);
+    let user_agent_value = format!("Wasm Workers Server/{VERSION}");
 
     let body: Vec<u8> = client
         .get(file.as_ref())

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,11 +87,11 @@ async fn not_found_html(req: &HttpRequest) -> HttpResponse {
 /// If no file is present, it will try to get a default "public/404.html"
 async fn find_static_html(uri_path: &str) -> Result<NamedFile, Error> {
     // File path. This is required for the wasm_handler as dynamic routes may capture static files
-    let file_path = ROOT_PATH.join(format!("public{}", uri_path));
+    let file_path = ROOT_PATH.join(format!("public{uri_path}"));
     // A.k.a pretty urls. We may access /about and this matches to /about/index.html
-    let index_folder_path = ROOT_PATH.join(format!("public{}/index.html", uri_path));
+    let index_folder_path = ROOT_PATH.join(format!("public{uri_path}/index.html"));
     // Same as before, but the file is located at ./about.html
-    let html_ext_path = ROOT_PATH.join(format!("public{}.html", uri_path));
+    let html_ext_path = ROOT_PATH.join(format!("public{uri_path}.html"));
 
     if file_path.exists() {
         NamedFile::open_async(file_path).await
@@ -226,28 +226,28 @@ async fn main() -> std::io::Result<()> {
             RuntimesCommands::List(list) => {
                 if let Err(err) = list.run(sub).await {
                     println!("❌ There was an error listing the runtimes from the repository");
-                    println!("👉 {}", err);
+                    println!("👉 {err}");
                     exit(1);
                 }
             }
             RuntimesCommands::Install(install) => {
                 if let Err(err) = install.run(&args.path, sub).await {
                     println!("❌ There was an error installing the runtime from the repository");
-                    println!("👉 {}", err);
+                    println!("👉 {err}");
                     exit(1);
                 }
             }
             RuntimesCommands::Uninstall(uninstall) => {
                 if let Err(err) = uninstall.run(&args.path, sub) {
                     println!("❌ There was an error uninstalling the runtime");
-                    println!("👉 {}", err);
+                    println!("👉 {err}");
                     exit(1);
                 }
             }
             RuntimesCommands::Check(check) => {
                 if let Err(err) = check.run(&args.path) {
                     println!("❌ There was an error checking the local runtimes");
-                    println!("👉 {}", err);
+                    println!("👉 {err}");
                     exit(1);
                 }
             }

--- a/src/router/route.rs
+++ b/src/router/route.rs
@@ -65,7 +65,7 @@ impl Route {
             match Config::try_from_file(config_path) {
                 Ok(c) => config = Some(c),
                 Err(err) => {
-                    eprintln!("{}", err);
+                    eprintln!("{err}");
                 }
             }
         }

--- a/src/router/routes.rs
+++ b/src/router/routes.rs
@@ -93,7 +93,7 @@ mod tests {
         let build_route = |file: &str| -> Route {
             Route::new(
                 Path::new("./tests/data/params"),
-                PathBuf::from(format!("./tests/data/params{}", file)),
+                PathBuf::from(format!("./tests/data/params{file}")),
                 "",
             )
         };
@@ -125,7 +125,7 @@ mod tests {
         let build_route = |file: &str| -> Route {
             Route::new(
                 Path::new("./tests/data/params"),
-                PathBuf::from(format!("./tests/data/params{}", file)),
+                PathBuf::from(format!("./tests/data/params{file}")),
                 "",
             )
         };

--- a/src/runtimes/manager.rs
+++ b/src/runtimes/manager.rs
@@ -26,8 +26,7 @@ pub fn init_runtime(project_root: &Path, path: &Path) -> Result<Box<dyn Runtime 
             )?)),
             "wasm" => Ok(Box::new(NativeRuntime::new(path.to_path_buf()))),
             _ => Err(anyhow!(format!(
-                "The '{}' extension does not have an associated runtime",
-                ext_as_str
+                "The '{ext_as_str}' extension does not have an associated runtime"
             ))),
         }
     } else {

--- a/src/runtimes/metadata.rs
+++ b/src/runtimes/metadata.rs
@@ -36,7 +36,7 @@ impl Repository {
     /// a result as the deserialization may fail.
     pub fn from_str(data: &str) -> Result<Self> {
         toml::from_str::<Repository>(data).map_err(|err| {
-            println!("Err: {:?}", err);
+            println!("Err: {err}");
             anyhow!("wws could not deserialize the repository metadata")
         })
     }

--- a/src/workers/worker.rs
+++ b/src/workers/worker.rs
@@ -89,7 +89,7 @@ impl Worker {
 
         let string_err = String::from_utf8(err_contents)?;
         if !string_err.is_empty() {
-            println!("Error: {}", string_err);
+            println!("Error: {string_err}");
         }
 
         let contents: Vec<u8> = stdout


### PR DESCRIPTION
Move all `println!` and `format!` argument to the new inline format. This will remove the errors from `clippy` and it makes the code more readable.

It closes #82 