### PR TITLE
feat: add tags to the runtime metadata

### DIFF
--- a/src/commands/runtimes.rs
+++ b/src/commands/runtimes.rs
@@ -160,14 +160,22 @@ impl List {
         table.add_row(Row::new(vec![
             Cell::new("Name"),
             Cell::new("Version"),
+            Cell::new("Tags"),
             Cell::new("Extension"),
             Cell::new("Binary"),
         ]));
 
         for runtime in &repo.runtimes {
+            let mut tags = runtime.tags.join(", ");
+
+            if tags.is_empty() {
+                tags.push('-');
+            }
+
             table.add_row(Row::new(vec![
                 Cell::new(&runtime.name),
                 Cell::new(&runtime.version),
+                Cell::new(&tags),
                 Cell::new(&runtime.extensions.join(", ")),
                 Cell::new(&runtime.binary.filename),
             ]));
@@ -199,13 +207,19 @@ impl Check {
             Cell::new("Installed"),
             Cell::new("Name"),
             Cell::new("Version"),
+            Cell::new("Tags"),
             Cell::new("Extension"),
             Cell::new("Binary"),
         ]));
 
         for repo in &config.repositories {
             for runtime in &repo.runtimes {
+                let mut tags = runtime.tags.join(", ");
                 let is_installed = check_runtime(project_root, &repo.name, runtime);
+
+                if tags.is_empty() {
+                    tags.push('-');
+                }
 
                 if !is_installed {
                     is_missing = true;
@@ -215,6 +229,7 @@ impl Check {
                     Cell::new(if is_installed { "✅" } else { "❌" }),
                     Cell::new(&runtime.name),
                     Cell::new(&runtime.version),
+                    Cell::new(&tags),
                     Cell::new(&runtime.extensions.join(", ")),
                     Cell::new(&runtime.binary.filename),
                 ]));

--- a/src/runtimes/metadata.rs
+++ b/src/runtimes/metadata.rs
@@ -62,9 +62,9 @@ impl Repository {
     }
 
     pub fn find_runtime(&self, name: &str, version: &str) -> Option<&Runtime> {
-        self.runtimes
-            .iter()
-            .find(|r| r.name == name && r.version == version)
+        self.runtimes.iter().find(|r| {
+            r.name == name && (r.version == version || r.tags.contains(&String::from(version)))
+        })
     }
 }
 
@@ -82,6 +82,9 @@ pub struct Runtime {
     pub name: String,
     /// Specific version of the runtime
     pub version: String,
+    /// Optional aliases for the version
+    #[serde(default)]
+    pub tags: Vec<String>,
     /// Current status in the repository
     pub status: RuntimeStatus,
     /// Associated extensions


### PR DESCRIPTION
Introduce the concept of `tags` to the runtime metadata. This will simplify how developers can install new runtimes by providing generic pointers to specific versions. It works similar to other platforms like OCI and Docker.

After installing it, the version will be locked on the `.wws.toml` file, so other developers will get always the same binaries when installing the runtime dependencies.

## CLI

```
$ wws runtimes list
⚙️  Fetching data from the repository...
┌────────┬─────────┬───────────┬───────────┬─────────────┐
│ Name   │ Version │ Tags      │ Extension │ Binary      │
├────────┼─────────┼───────────┼───────────┼─────────────┤
│ ruby   │ 3.2.0   │ latest, 3 │ rb        │ ruby.wasm   │
├────────┼─────────┼───────────┼───────────┼─────────────┤
│ python │ 3.11.1  │ latest, 3 │ py        │ python.wasm │
└────────┴─────────┴───────────┴───────────┴─────────────┘

$ wws runtimes install ruby latest
⚙️  Fetching data from the repository...
🚀 Installing the runtime...
✅ Done

$ wws runtimes check
┌───────────┬──────┬─────────┬───────────┬───────────┬───────────┐
│ Installed │ Name │ Version │ Tags      │ Extension │ Binary    │
├───────────┼──────┼─────────┼───────────┼───────────┼───────────┤
│ ✅        │ ruby │ 3.2.0   │ latest, 3 │ rb        │ ruby.wasm │
└───────────┴──────┴─────────┴───────────┴───────────┴───────────┘
```

It closes #86 