### PR TITLE
feat: check missing runtimes before loading workers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod store;
 mod workers;
 
 use crate::config::Config;
+use crate::runtimes::manager::check_runtimes;
 use actix_files::{Files, NamedFile};
 use actix_web::dev::{fn_service, ServiceRequest, ServiceResponse};
 use actix_web::{
@@ -269,6 +270,12 @@ async fn main() -> std::io::Result<()> {
                 Config::default()
             }
         };
+
+        // Check if there're missing runtimes
+        if check_runtimes(&args.path, &config) {
+            println!("⚠️  Required language runtimes are not installed. Some files may not be considered workers");
+            println!("⚠️  You can install the missing runtimes with: wws runtimes install");
+        }
 
         println!("⚙️  Loading routes from: {}", &args.path.display());
         let routes = Data::new(Routes::new(&args.path, &args.prefix, &config));

--- a/src/router/files.rs
+++ b/src/router/files.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::Config;
+use crate::runtimes::manager::check_runtime;
 use crate::store::STORE_FOLDER;
 use std::ffi::OsStr;
 use std::path::{Component, Path, PathBuf};
@@ -29,7 +30,7 @@ impl Files {
         for repo in &config.repositories {
             for runtime in &repo.runtimes {
                 for ext in &runtime.extensions {
-                    if !extensions.contains(ext) {
+                    if check_runtime(root, &repo.name, runtime) && !extensions.contains(ext) {
                         extensions.push(ext.clone());
                     }
                 }

--- a/src/runtimes/manager.rs
+++ b/src/runtimes/manager.rs
@@ -132,18 +132,15 @@ pub fn check_runtime(project_root: &Path, repository: &str, runtime: &RuntimeMet
 
 /// Check if there're missing runtimes based on the current configuration
 pub fn check_runtimes(project_root: &Path, config: &Config) -> bool {
-    let mut missing = false;
-
-    'outer: for repo in &config.repositories {
+    for repo in &config.repositories {
         for runtime in &repo.runtimes {
             if !check_runtime(project_root, &repo.name, runtime) {
-                missing = true;
-                break 'outer;
+                return true;
             }
         }
     }
 
-    missing
+    false
 }
 
 // Install a given runtime based on its metadata

--- a/src/runtimes/manager.rs
+++ b/src/runtimes/manager.rs
@@ -130,6 +130,22 @@ pub fn check_runtime(project_root: &Path, repository: &str, runtime: &RuntimeMet
     binary && template && polyfill && wrapper
 }
 
+/// Check if there're missing runtimes based on the current configuration
+pub fn check_runtimes(project_root: &Path, config: &Config) -> bool {
+    let mut missing = false;
+
+    'outer: for repo in &config.repositories {
+        for runtime in &repo.runtimes {
+            if !check_runtime(project_root, &repo.name, runtime) {
+                missing = true;
+                break 'outer;
+            }
+        }
+    }
+
+    missing
+}
+
 // Install a given runtime based on its metadata
 pub fn uninstall_runtime(
     project_root: &Path,


### PR DESCRIPTION
When a user downloads an existing project, the required runtimes won't be installed. As part of the process, they need to download it using `wws runtimes install` as other similar tools like `NodeJS`. We want to provide a hint about this behavior so `wws` doesn't fail and it shows useful information.

From now on, `wws` will look for missing runtimes when running the `run` command (default one). If there're missing runtimes, it will show a message and will ask users to install it using `wws runtimes install`. In the future, we will evaluate if installing missing runtimes should be part of the regular process.

In addition to that, now `wws` will ignore the extensions of not installed runtimes.

```
./wws .
⚠️  Required language runtimes are not installed. Some files may not be considered workers
⚠️  You can install the missing runtimes with: wws runtimes install
⚙️  Loading routes from: .
🗺  Detected routes:
🚀 Start serving requests at http://127.0.0.1:8080
```

It closes #69