### PR TITLE
fix: send the query string to the workers

### DIFF
--- a/src/workers/wasm_io.rs
+++ b/src/workers/wasm_io.rs
@@ -42,8 +42,13 @@ impl<'a> WasmInput<'a> {
             params.insert(k.to_string(), v.to_string());
         }
 
+        let url = match request.uri().path_and_query() {
+            Some(path) => path.as_str(),
+            None => request.uri().path(),
+        };
+
         Self {
-            url: request.uri().path(),
+            url,
             method: request.method().as_str(),
             headers: Self::build_headers_hash(request.headers()),
             body,


### PR DESCRIPTION
Ensure we send the URL + query string to the workers when running them. This will allow workers to identify values on the query string and perform actions based on them.

It closes #92 