### PR TITLE
fix: avoid exiting as Tokio needs to manage open threads. Fix typo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ use data::kv::KV;
 use router::Routes;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
-use std::process::exit;
 use std::{collections::HashMap, sync::RwLock};
 use workers::wasm_io::WasmOutput;
 
@@ -225,38 +224,40 @@ async fn main() -> std::io::Result<()> {
 
     // Check the given subcommand
     if let Some(Main::Runtimes(sub)) = &args.commands {
+        let mut run_result = Ok(());
+
         match &sub.runtime_commands {
             RuntimesCommands::List(list) => {
                 if let Err(err) = list.run(sub).await {
                     println!("❌ There was an error listing the runtimes from the repository");
                     println!("👉 {err}");
-                    exit(1);
+                    run_result = Err(Error::new(ErrorKind::InvalidData, ""));
                 }
             }
             RuntimesCommands::Install(install) => {
                 if let Err(err) = install.run(&args.path, sub).await {
                     println!("❌ There was an error installing the runtime from the repository");
                     println!("👉 {err}");
-                    exit(1);
+                    run_result = Err(Error::new(ErrorKind::InvalidData, ""));
                 }
             }
             RuntimesCommands::Uninstall(uninstall) => {
                 if let Err(err) = uninstall.run(&args.path, sub) {
                     println!("❌ There was an error uninstalling the runtime");
                     println!("👉 {err}");
-                    exit(1);
+                    run_result = Err(Error::new(ErrorKind::InvalidData, ""));
                 }
             }
             RuntimesCommands::Check(check) => {
                 if let Err(err) = check.run(&args.path) {
                     println!("❌ There was an error checking the local runtimes");
                     println!("👉 {err}");
-                    exit(1);
+                    run_result = Err(Error::new(ErrorKind::InvalidData, ""));
                 }
             }
         };
 
-        Ok(())
+        run_result
     } else {
         // TODO(Angelmmiguel): refactor this into a separate command!
         // Initialize the routes

--- a/src/runtimes/metadata.rs
+++ b/src/runtimes/metadata.rs
@@ -164,7 +164,7 @@ impl Checksum {
     pub fn validate(&self, bytes: &[u8]) -> Result<()> {
         match self {
             Checksum::Sha256 { value } if value == &sha256_digest(bytes) => Ok(()),
-            _ => Err(anyhow!("The checksums dont not match")),
+            _ => Err(anyhow!("The checksums don't match")),
         }
     }
 }


### PR DESCRIPTION
Properly manage errors when running commands by using the `Result` return value. Before, I was exiting the CLI earlier and that was causing the app to panik. The reason is that, Actix uses Tokio under the hood for managing async code. Tokio need to manage the entire application to ensure the threads are properly finished. By exiting early, we force the program to panik.

I also fixed a small typo.

## Result

```
./wws install ruby latest
⚙️  Fetching data from the repository...
🚀 Installing the runtime...
❌ There was an error installing the runtime from the repository
👉 The checksums don't match
Error: Custom { kind: InvalidData, error: "" }
```

I couldn't remove the "Error: Custom" message for now. However, this is much better than the previous output so I'll investigate why this is happening in a future version.

It closes #96 