### PR TITLE
Display a message with the number of detected workers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -279,8 +279,15 @@ async fn main() -> std::io::Result<()> {
             println!("⚠️  You can install the missing runtimes with: wws runtimes install");
         }
 
+        let files = router::files::Files::new(&args.path, &config);
+        let entries = files.walk();
+        println!(
+            "⚙️  {} files are identified as workers. Start processing them",
+            entries.len()
+        );
+
         println!("⚙️  Loading routes from: {}", &args.path.display());
-        let routes = Data::new(Routes::new(&args.path, &args.prefix, &config));
+        let routes = Data::new(Routes::new(entries, &args.path, &args.prefix, &config));
 
         let data = Data::new(RwLock::new(DataConnectors { kv: KV::new() }));
 

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-mod files;
+pub mod files;
 mod route;
 mod routes;
 

--- a/src/router/routes.rs
+++ b/src/router/routes.rs
@@ -5,11 +5,10 @@
 // Declare the different routes for the project
 // based on the files in the given folder
 //
-use std::path::Path;
-
-use super::files::Files;
 use super::route::{Route, RouteAffinity};
 use crate::config::Config;
+use std::path::Path;
+use wax::WalkEntry;
 
 /// Contains all registered routes
 pub struct Routes {
@@ -21,12 +20,11 @@ impl Routes {
     /// Initialize the list of routes from the given folder. This method will look for
     /// different files and will create the associated routes. This routing approach
     /// is pretty popular in web development and static sites.
-    pub fn new(path: &Path, base_prefix: &str, config: &Config) -> Self {
+    pub fn new(entries: Vec<WalkEntry>, path: &Path, base_prefix: &str, config: &Config) -> Self {
         let mut routes = Vec::new();
         let prefix = Self::format_prefix(base_prefix);
-        let files = Files::new(path, config);
 
-        for entry in files.walk() {
+        for entry in entries {
             routes.push(Route::new(path, entry.into_path(), &prefix, config));
         }
 


### PR DESCRIPTION
As described in #103, This PR adds a message the number of workers before processing them.

You can see the message like below.
```
% cargo build
% cd examples/
% ../target/debug/wws .
⚙️  8 files are identified as workers. Start processing them
⚙️  Loading routes from: .
🗺  Detected routes:
    - http://127.0.0.1:8080/js-redirect/handler
      => ./js-redirect/handler.js (name: default)
    - http://127.0.0.1:8080/js-json/handler
      => ./js-json/handler.js (name: test)
    - http://127.0.0.1:8080/js-basic
      => ./js-basic/index.js (name: default)
    - http://127.0.0.1:8080/js-tictactoe/handler
      => ./js-tictactoe/handler.js (name: tictactoe)
    - http://127.0.0.1:8080/js-params/[id]
      => ./js-params/[id].js (name: default)
    - http://127.0.0.1:8080/js-params/fixed
      => ./js-params/fixed.js (name: default)
    - http://127.0.0.1:8080/js-params/sub/[id]
      => ./js-params/sub/[id].js (name: default)
    - http://127.0.0.1:8080/js-params/[id]/fixed
      => ./js-params/[id]/fixed.js (name: default)
🚀 Start serving requests at http://127.0.0.1:8080
```

resolve #103