### PR TITLE
feat: allow mounting folders in workers

### DIFF
--- a/crates/data-kv/src/lib.rs
+++ b/crates/data-kv/src/lib.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use store::KVStore;
 
 /// The Key/Value store configuration. This information is read from workers TOML files.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Default)]
 pub struct KVConfigData {
     /// The namespace the worker will access in the global Key / Value store
     pub namespace: String,

--- a/crates/server/src/handlers/worker.rs
+++ b/crates/server/src/handlers/worker.rs
@@ -8,7 +8,7 @@ use actix_web::{
     web::{Bytes, Data},
     HttpRequest, HttpResponse,
 };
-use std::{collections::HashMap, sync::RwLock};
+use std::sync::RwLock;
 use wws_router::Routes;
 use wws_worker::io::WasmOutput;
 
@@ -55,17 +55,8 @@ pub async fn handle_worker(req: HttpRequest, body: Bytes) -> HttpResponse {
         let body_str = String::from_utf8(body.to_vec()).unwrap_or_else(|_| String::from(""));
 
         // Init from configuration
-        let empty_hash = HashMap::new();
-        let mut vars = &empty_hash;
-        let mut kv_namespace = None;
-
-        match &route.config {
-            Some(config) => {
-                kv_namespace = config.data_kv_namespace();
-                vars = &config.vars;
-            }
-            None => {}
-        };
+        let vars = &route.worker.config.vars;
+        let kv_namespace = route.worker.config.data_kv_namespace();
 
         let store = match &kv_namespace {
             Some(namespace) => {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -52,7 +52,7 @@ pub async fn serve(
             app = app.service(web::resource(route.actix_path()).to(handle_worker));
 
             // Configure KV
-            if let Some(namespace) = route.config.as_ref().and_then(|c| c.data_kv_namespace()) {
+            if let Some(namespace) = route.worker.config.data_kv_namespace() {
                 data.write().unwrap().kv.create_store(&namespace);
             }
         }

--- a/examples/python-mount/.wws.toml
+++ b/examples/python-mount/.wws.toml
@@ -1,0 +1,44 @@
+version = 1
+
+[[repositories]]
+name = "wasmlabs"
+url = "https://workers.wasmlabs.dev/repository/v1/index.toml"
+
+[[repositories.runtimes]]
+name = "python"
+version = "3.11.1+20230217"
+tags = [
+    "latest",
+    "3.11",
+    "3.11.1",
+]
+status = "active"
+extensions = ["py"]
+args = [
+    "--",
+    "/src/index.py",
+]
+
+[repositories.runtimes.binary]
+url = "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.1%2B20230217-15dfbed/python-3.11.1.wasm"
+filename = "python.wasm"
+
+[repositories.runtimes.binary.checksum]
+type = "sha256"
+value = "66589b289f76bd716120f76f234e4dd663064ed5b6256c92d441d84e51d7585d"
+
+[repositories.runtimes.polyfill]
+url = "https://workers.wasmlabs.dev/repository/v1/files/python/3/poly.py"
+filename = "poly.py"
+
+[repositories.runtimes.polyfill.checksum]
+type = "sha256"
+value = "2027b73556ca02155f026cee751ab736985917d2f28bbcad5aac928c719e1112"
+
+[repositories.runtimes.wrapper]
+url = "https://workers.wasmlabs.dev/repository/v1/files/python/3/wrapper.txt"
+filename = "wrapper.txt"
+
+[repositories.runtimes.wrapper.checksum]
+type = "sha256"
+value = "cf1edc5b1427180ec09d18f4d169580379f1b12001f30e330759f9a0f8745357"

--- a/examples/python-mount/_assets/index.html
+++ b/examples/python-mount/_assets/index.html
@@ -1,0 +1,1 @@
+<h1>This page was loaded from a mounted file!</h1>

--- a/examples/python-mount/index.py
+++ b/examples/python-mount/index.py
@@ -1,0 +1,7 @@
+# Read a mounted file and return it
+def worker(request):
+    s = ""
+    with open("/src/assets/index.html") as f:
+        s = f.read()
+
+    return Response(s)

--- a/examples/python-mount/index.toml
+++ b/examples/python-mount/index.toml
@@ -1,0 +1,5 @@
+version = "1"
+
+[[folders]]
+from = "./_assets"
+to = "/src/assets"

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,20 +106,12 @@ async fn main() -> std::io::Result<()> {
 
         println!("🗺  Detected routes:");
         for route in routes.routes.iter() {
-            let default_name = String::from("default");
-            let name = if let Some(config) = &route.config {
-                config.name.as_ref().unwrap_or(&default_name)
-            } else {
-                &default_name
-            };
-
             println!(
-                "    - http://{}:{}{}\n      => {} (name: {})",
+                "    - http://{}:{}{}\n      => {}",
                 &args.hostname,
                 args.port,
                 route.path,
-                route.handler.display(),
-                name
+                route.handler.display()
             );
         }
 


### PR DESCRIPTION
Introduce a new feature to mount arbitrary folders in a specific workers. It allows developers to provide assets and libraries to the workers as they need. To mount a folder, you only need to add a new configuration parameter in the worker config:

```toml
version = "1"

[[folders]]
from = "./_assets"
to = "/src/assets"
```

Note this configuration is defined at worker level. Every worker can define their own sets of required folders.

## Other changes

- Move the worker configuration from the `Route` struct to the `Worker`
- Remove the `name` config property from the CLI output. It's not providing any meaningful information
- Provide always a default configuration to avoid dealing with `Option`
- Add a new `python-mount` example
- Ignore files and folders that starts with `_`. Those will be the folders that will be mounted later on

It closes #53 