### PR TITLE
feat: add binary data management on both Python and Ruby polyfills

### DIFF
--- a/metadata/repository/v1/files/python/3-1/poly.py
+++ b/metadata/repository/v1/files/python/3-1/poly.py
@@ -1,0 +1,55 @@
+import sys, json, base64
+
+class Cache:
+    store = {}
+
+    @classmethod
+    def init(cls, kv):
+        cls.store = kv
+
+    @classmethod
+    def dump(cls):
+        return cls.store
+
+    @classmethod
+    def get(cls, key):
+        return cls.store.get(key)
+
+    @classmethod
+    def set(cls, key, value):
+        cls.store[key] = str(value)
+
+class Request:
+    def __init__(self, input):
+        self.method = input["method"]
+        self.url = input["url"]
+        self.body = input["body"]
+        self.headers = input["headers"]
+        self.params = input["params"]
+
+        # Init the cache
+        Cache.init(input["kv"])
+
+class Response:
+    def __init__(self, body):
+        self.body = body
+        self.status_code = 200
+        self.headers = {}
+
+    def to_json(self):
+        content = self.body
+        encoded = False
+
+        if type(self.body) is bytes:
+            content = base64.b64encode(self.body).decode('utf-8')
+            encoded = True
+
+        res = {
+            'data': content,
+            'status': self.status_code,
+            'headers': self.headers,
+            'kv': Cache.dump(),
+            'base64': encoded
+        }
+
+        return json.dumps(res)

--- a/metadata/repository/v1/files/python/3-1/wrapper.txt
+++ b/metadata/repository/v1/files/python/3-1/wrapper.txt
@@ -1,0 +1,6 @@
+from poly import *
+
+{source}
+
+res = worker(Request(json.loads(sys.stdin.read())))
+print(res.to_json())

--- a/metadata/repository/v1/files/ruby/3-1/poly.rb
+++ b/metadata/repository/v1/files/ruby/3-1/poly.rb
@@ -1,0 +1,89 @@
+require 'json';
+
+def json_to_request(input)
+  json = JSON.parse(input);
+
+  Request.new(
+    json['url'],
+    json['body'],
+    json['method'],
+    json['headers'],
+    json['params'],
+    json['kv']
+  )
+end
+
+class Cache
+  @@kv = {}
+
+  def self.init(kv)
+    @@kv = kv
+  end
+
+  def self.dump
+    @@kv
+  end
+
+  def self.get(key)
+    @@kv[key.to_s]
+  end
+
+  def self.set(key, value)
+    @@kv[key.to_s] = value.to_s
+  end
+end
+
+class Request
+  attr_reader :url, :body, :method, :headers, :params
+
+  def initialize(url, body, method, headers, params, kv)
+    @url = url
+    @body = body
+    @method = method
+    @headers = headers
+    @params = params
+
+    # Initializes the cache
+    Cache.init(kv)
+  end
+end
+
+class Response
+  attr_accessor :body, :status_code, :headers
+
+  def initialize(body, status_code = 200, headers = {})
+    @body = body
+    @status_code = status_code
+    @headers = headers
+  end
+
+  def self.ok(body)
+    new(body)
+  end
+
+  def self.created(body)
+    new(body, 201)
+  end
+
+  def self.not_found(body)
+    new(body, 404)
+  end
+
+  def to_s
+    content = body
+    encoded = false
+
+    if body.encoding.name != "UTF-8"
+      content = [body].pack("m0")
+      encoded = true
+    end
+
+    JSON.generate({
+      data: content,
+      status: status_code,
+      headers: headers,
+      kv: Cache.dump,
+      base64: encoded
+    })
+  end
+end

--- a/metadata/repository/v1/files/ruby/3-1/wrapper.txt
+++ b/metadata/repository/v1/files/ruby/3-1/wrapper.txt
@@ -1,0 +1,5 @@
+require_relative "./poly";
+
+{source}
+
+puts "#{worker(json_to_request($stdin.gets.to_s))}"

--- a/metadata/repository/v1/index.toml
+++ b/metadata/repository/v1/index.toml
@@ -2,8 +2,30 @@ version = 1
 
 [[runtimes]]
 name = "ruby"
-version = "3.2.0+20230215"
+version = "3.2.0+20230215-1"
 tags = [ "latest", "3.2", "3.2.0" ]
+status = "active"
+args = [ "--", "/src/index.rb" ]
+binary = { url = "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/ruby%2F3.2.0%2B20230215-1349da9/ruby-3.2.0.wasm", filename = "ruby.wasm", checksum = { type = "sha256", value = "abe348fba157a756f86194be445c77c99e8ed64ca76495ea07ed984f09eb66ae" } }
+extensions = [ "rb" ]
+polyfill = { url = "https://workers.wasmlabs.dev/repository/v1/files/ruby/3-1/poly.rb", filename = "poly.rb", checksum = { type = "sha256", value = "449855a5d315879ab0ad830aa6a3f689e68fed4490617ea03efc77c9da64f630" } }
+wrapper = { url = "https://workers.wasmlabs.dev/repository/v1/files/ruby/3-1/wrapper.txt", filename = "wrapper.txt", checksum = { type = "sha256", value = "6d808b4747cf30f82665a38a47e1176513bbdd6ad558c09db03d719e33ad2da0" } }
+
+[[runtimes]]
+name = "python"
+version = "3.11.1+20230217-1"
+tags = [ "latest", "3.11", "3.11.1" ]
+status = "active"
+args = [ "--", "/src/index.py" ]
+binary = { url = "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.1%2B20230217-15dfbed/python-3.11.1.wasm", filename = "python.wasm", checksum = { type = "sha256", value = "66589b289f76bd716120f76f234e4dd663064ed5b6256c92d441d84e51d7585d" } }
+extensions = [ "py" ]
+polyfill = { url = "https://workers.wasmlabs.dev/repository/v1/files/python/3-1/poly.py", filename = "poly.py", checksum = { type = "sha256", value = "74d10132b0577a39e4ea30002d4605b7cdfb8f39abca327a45c8b313de7ea304" } }
+wrapper = { url = "https://workers.wasmlabs.dev/repository/v1/files/python/3-1/wrapper.txt", filename = "wrapper.txt", checksum = { type = "sha256", value = "cf1edc5b1427180ec09d18f4d169580379f1b12001f30e330759f9a0f8745357" } }
+
+[[runtimes]]
+name = "ruby"
+version = "3.2.0+20230215"
+tags = [ ]
 status = "active"
 args = [ "--", "/src/index.rb" ]
 binary = { url = "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/ruby%2F3.2.0%2B20230215-1349da9/ruby-3.2.0.wasm", filename = "ruby.wasm", checksum = { type = "sha256", value = "abe348fba157a756f86194be445c77c99e8ed64ca76495ea07ed984f09eb66ae" } }
@@ -14,7 +36,7 @@ wrapper = { url = "https://workers.wasmlabs.dev/repository/v1/files/ruby/3/wrapp
 [[runtimes]]
 name = "python"
 version = "3.11.1+20230217"
-tags = [ "latest", "3.11", "3.11.1" ]
+tags = [ ]
 status = "active"
 args = [ "--", "/src/index.py" ]
 binary = { url = "https://github.com/vmware-labs/webassembly-language-runtimes/releases/download/python%2F3.11.1%2B20230217-15dfbed/python-3.11.1.wasm", filename = "python.wasm", checksum = { type = "sha256", value = "66589b289f76bd716120f76f234e4dd663064ed5b6256c92d441d84e51d7585d" } }


### PR DESCRIPTION
Introduce binary data management for Ruby and Python polyfills. To avoid issues with existing users, I added a new branch for the Ruby / Python polyfill and wrapper. I set the tags to the latest version, so new installations will use the new features.

It closes #109 