### PR TITLE
fix: pass the root_path as shared data in actix

### DIFF
--- a/crates/server/src/handlers/assets.rs
+++ b/crates/server/src/handlers/assets.rs
@@ -5,7 +5,7 @@ use actix_files::NamedFile;
 use actix_web::{web::Data, HttpRequest};
 use std::{
     io::{Error, ErrorKind},
-    path::Path,
+    path::PathBuf,
 };
 
 /// Find a static HTML file in the `public` folder. This function is used
@@ -14,7 +14,7 @@ use std::{
 ///
 /// If no file is present, it will try to get a default "public/404.html"
 pub async fn handle_assets(req: &HttpRequest) -> Result<NamedFile, Error> {
-    let root_path = req.app_data::<Data<&Path>>().unwrap();
+    let root_path = req.app_data::<Data<PathBuf>>().unwrap();
     let uri_path = req.path();
 
     // File path. This is required for the wasm_handler as dynamic routes may capture static files

--- a/crates/server/src/handlers/not_found.rs
+++ b/crates/server/src/handlers/not_found.rs
@@ -3,12 +3,12 @@
 
 use actix_files::NamedFile;
 use actix_web::{web::Data, HttpRequest, HttpResponse};
-use std::path::Path;
+use std::path::PathBuf;
 
 /// This method tries to render a custom 404 error file from the static
 /// folder. If not, it will render an empty 404
 pub async fn handle_not_found(req: &HttpRequest) -> HttpResponse {
-    let root_path = req.app_data::<Data<&Path>>().unwrap();
+    let root_path = req.app_data::<Data<PathBuf>>().unwrap();
     let public_404_path = root_path.join("public").join("404.html");
 
     if let Ok(file) = NamedFile::open_async(public_404_path).await {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -45,7 +45,8 @@ pub async fn serve(
             // Clean path before sending it to the service
             .wrap(middleware::NormalizePath::trim())
             .app_data(Data::clone(&routes))
-            .app_data(Data::clone(&data));
+            .app_data(Data::clone(&data))
+            .app_data(Data::clone(&root_path));
 
         // Append routes to the current service
         for route in routes.routes.iter() {


### PR DESCRIPTION
Ensure the `root_path` property is passed as a Actix data to the handlers. I also fixed the type to the right one. After applying it, `wws` is properly returning the 404 or the static asset:

## Favicon.ico is missing

```
⚙️  Loading routes from: ./examples/js-basic
🗺  Detected routes:
    - http://127.0.0.1:9090/
      => ./examples/js-basic/index.js (name: default)
🚀 Start serving requests at http://127.0.0.1:9090

[2023-03-15T16:19:15Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET / HTTP/1.1" 200 827 "-" "..." 0.028136
[2023-03-15T16:19:15Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /favicon.ico HTTP/1.1" 404 0 "http://localhost:9090/" "..." 0.001388
```

## Favicon.ico is present

```
⚙️  Loading routes from: ./examples/js-basic
🗺  Detected routes:
    - http://127.0.0.1:9090/
      => ./examples/js-basic/index.js (name: default)
🚀 Start serving requests at http://127.0.0.1:9090

[2023-03-15T16:19:15Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET / HTTP/1.1" 200 827 "-" "..." 0.028136
[2023-03-15T16:20:44Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /favicon.ico HTTP/1.1" 200 15406 "http://localhost:9090/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/109.0" 0.005634
```

It closes #111 