### PR TITLE
update: bump openssl crate to 0.10.48

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,9 +1762,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1803,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ wws-server = { workspace = true }
 wws-runtimes-manager = { workspace = true }
 
 [target.x86_64-unknown-linux-musl.dependencies]
-openssl = { version = "=0.10.45", features = ["vendored"] }
+openssl = { version = "=0.10.48", features = ["vendored"] }
 
 [target.aarch64-unknown-linux-musl.dependencies]
-openssl = { version = "=0.10.45", features = ["vendored"] }
+openssl = { version = "=0.10.48", features = ["vendored"] }
 
 [workspace]
 members = [


### PR DESCRIPTION
Upgrade the [openssl](https://crates.io/crates/openssl) crate to 0.10.48

It closes #118 