### PR TITLE
feat: allow configuring stderr when running the server

### DIFF
--- a/crates/server/src/handlers/worker.rs
+++ b/crates/server/src/handlers/worker.rs
@@ -8,7 +8,7 @@ use actix_web::{
     web::{Bytes, Data},
     HttpRequest, HttpResponse,
 };
-use std::{sync::RwLock, fs::File};
+use std::{fs::File, sync::RwLock};
 use wws_router::Routes;
 use wws_worker::io::WasmOutput;
 
@@ -69,11 +69,14 @@ pub async fn handle_worker(req: HttpRequest, body: Bytes) -> HttpResponse {
             None => None,
         };
 
-        let (handler_result, handler_success) = match route.worker.run(&req, &body_str, store, vars, stderr_file.get_ref())
-        {
-            Ok(output) => (output, true),
-            Err(_) => (WasmOutput::failed(), false),
-        };
+        let (handler_result, handler_success) =
+            match route
+                .worker
+                .run(&req, &body_str, store, vars, stderr_file.get_ref())
+            {
+                Ok(output) => (output, true),
+                Err(_) => (WasmOutput::failed(), false),
+            };
 
         let mut builder = HttpResponse::build(
             StatusCode::from_u16(handler_result.status).unwrap_or(StatusCode::OK),

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 use handlers::assets::handle_assets;
 use handlers::not_found::handle_not_found;
 use handlers::worker::handle_worker;
+use std::fs::OpenOptions;
 use std::path::Path;
 use std::sync::RwLock;
 use wws_data_kv::KV;
@@ -32,11 +33,25 @@ pub async fn serve(
     base_routes: Routes,
     hostname: &str,
     port: u16,
+    stderr: Option<&Path>
 ) -> Result<Server> {
     // Initializes the data connectors. For now, just KV
     let data = Data::new(RwLock::new(DataConnectors::default()));
     let routes = Data::new(base_routes);
     let root_path = Data::new(root_path.to_owned());
+    let stderr_file;
+
+    // Configure stderr
+    if let Some(path) = stderr {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)?;
+
+        stderr_file = Data::new(Some(file));
+    } else {
+        stderr_file = Data::new(None);
+    }
 
     let server = HttpServer::new(move || {
         let mut app = App::new()
@@ -46,7 +61,8 @@ pub async fn serve(
             .wrap(middleware::NormalizePath::trim())
             .app_data(Data::clone(&routes))
             .app_data(Data::clone(&data))
-            .app_data(Data::clone(&root_path));
+            .app_data(Data::clone(&root_path))
+            .app_data(Data::clone(&stderr_file));
 
         // Append routes to the current service
         for route in routes.routes.iter() {

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -33,7 +33,7 @@ pub async fn serve(
     base_routes: Routes,
     hostname: &str,
     port: u16,
-    stderr: Option<&Path>
+    stderr: Option<&Path>,
 ) -> Result<Server> {
     // Initializes the data connectors. For now, just KV
     let data = Data::new(RwLock::new(DataConnectors::default()));
@@ -43,10 +43,7 @@ pub async fn serve(
 
     // Configure stderr
     if let Some(path) = stderr {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)?;
+        let file = OpenOptions::new().read(true).write(true).open(path)?;
 
         stderr_file = Data::new(Some(file));
     } else {

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -9,10 +9,10 @@ use actix_web::HttpRequest;
 use anyhow::{anyhow, Result};
 use config::Config;
 use io::{WasmInput, WasmOutput};
-use stdio::Stdio;
 use std::fs::{self, File};
 use std::path::PathBuf;
 use std::{collections::HashMap, path::Path};
+use stdio::Stdio;
 use wasmtime::{Engine, Linker, Module, Store};
 use wasmtime_wasi::{Dir, WasiCtxBuilder};
 use wws_config::Config as ProjectConfig;
@@ -73,7 +73,7 @@ impl Worker {
         body: &str,
         kv: Option<HashMap<String, String>>,
         vars: &HashMap<String, String>,
-        stderr: &Option<File>
+        stderr: &Option<File>,
     ) -> Result<WasmOutput> {
         let input = serde_json::to_string(&WasmInput::new(request, body, kv)).unwrap();
 
@@ -97,8 +97,7 @@ impl Worker {
             vars.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
 
         // Create the initial WASI context
-        let mut wasi_builder = WasiCtxBuilder::new()
-            .envs(&tuple_vars)?;
+        let mut wasi_builder = WasiCtxBuilder::new().envs(&tuple_vars)?;
 
         // Configure the stdio
         wasi_builder = stdio.configure_wasi_ctx(wasi_builder);

--- a/crates/worker/src/stdio.rs
+++ b/crates/worker/src/stdio.rs
@@ -39,11 +39,14 @@ impl Stdio {
             stderr
         }
     }
+
     pub fn configure_wasi_ctx(&self, builder: WasiCtxBuilder) -> WasiCtxBuilder {
         let builder = builder
             .stdin(Box::new(self.stdin.clone()))
             .stdout(Box::new(self.stdout.clone()));
 
+        // Set stderr if it was previously configured. If not, inherit
+        // it from the environment
         if let Some(pipe) = self.stderr.clone() {
             builder.stderr(Box::new(pipe))
         } else {

--- a/crates/worker/src/stdio.rs
+++ b/crates/worker/src/stdio.rs
@@ -1,0 +1,53 @@
+use std::{io::Cursor, fs::{File}};
+use wasi_common::pipe::{ReadPipe, WritePipe};
+use wasmtime_wasi::WasiCtxBuilder;
+
+/// A library to configure the stdio of the WASI context.
+/// Note that currently, wws relies on stdin and stdout
+/// to send and read data from the worker.
+///
+/// The stderr is configurable just to cover use cases in which
+/// wws is used as a library and we want to expose the logs
+///
+/// @see https://github.com/vmware-labs/wasm-workers-server/issues/125
+///
+/// The stdin/stdout approach will change in the future with
+/// a more performant and appropiate way.
+pub struct Stdio {
+    /// Defines the stdin ReadPipe to send the data to the module
+    pub stdin: ReadPipe<Cursor<String>>,
+    /// Defines the stdout to extract the data from the module
+    pub stdout: WritePipe<Cursor<Vec<u8>>>,
+    /// Defines the stderr to expose logs from inside the module
+    pub stderr: Option<WritePipe<File>>
+}
+
+impl Stdio {
+    /// Initialize the stdio. The stdin will contain the input data.
+    pub fn new(input: &str, stderr_file: Option<File>) -> Self {
+        let stderr;
+
+        if let Some(file) = stderr_file {
+            stderr = Some(WritePipe::new(file));
+        } else {
+            stderr = None
+        }
+
+        Self {
+            stdin: ReadPipe::from(input),
+            stdout: WritePipe::new_in_memory(),
+            stderr
+        }
+    }
+    pub fn configure_wasi_ctx(&self, builder: WasiCtxBuilder) -> WasiCtxBuilder {
+        let builder = builder
+            .stdin(Box::new(self.stdin.clone()))
+            .stdout(Box::new(self.stdout.clone()));
+
+        if let Some(pipe) = self.stderr.clone() {
+            builder.stderr(Box::new(pipe))
+        } else {
+            builder.inherit_stderr()
+        }
+    }
+}

--- a/crates/worker/src/stdio.rs
+++ b/crates/worker/src/stdio.rs
@@ -1,4 +1,4 @@
-use std::{io::Cursor, fs::{File}};
+use std::{fs::File, io::Cursor};
 use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasmtime_wasi::WasiCtxBuilder;
 
@@ -19,7 +19,7 @@ pub struct Stdio {
     /// Defines the stdout to extract the data from the module
     pub stdout: WritePipe<Cursor<Vec<u8>>>,
     /// Defines the stderr to expose logs from inside the module
-    pub stderr: Option<WritePipe<File>>
+    pub stderr: Option<WritePipe<File>>,
 }
 
 impl Stdio {
@@ -36,7 +36,7 @@ impl Stdio {
         Self {
             stdin: ReadPipe::from(input),
             stdout: WritePipe::new_in_memory(),
-            stderr
+            stderr,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ async fn main() -> std::io::Result<()> {
             );
         }
 
-        let server = serve(&args.path, routes, &args.hostname, args.port)
+        let server = serve(&args.path, routes, &args.hostname, args.port, None)
             .await
             .map_err(|err| Error::new(ErrorKind::AddrInUse, err))?;
 


### PR DESCRIPTION
Allow to configure the `stderr` in the WASI context that runs the workers. This will allow a Wasm module to print the error logs in a specific file when configured. 

This value is optional. If it's not configured, it will inherit the value from the environment.

It closes #125 

## containerd-wasm-shims

This feature was implemented to allow modules print messages in a custom stderr for deislabs/containerd-wasm-shims/pull/88. Here you can see the logs printed in the proper location:

![Screenshot 2023-05-08 at 09 05 06](https://user-images.githubusercontent.com/4056725/236757348-1e05b1b0-b6d2-4346-8355-6ed5ba6a9af3.png)
