### PR TITLE
fix: use open_ambient_dir instead of fs::File::open to load folders

### DIFF
--- a/crates/runtimes/src/modules/external.rs
+++ b/crates/runtimes/src/modules/external.rs
@@ -7,7 +7,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use wasmtime_wasi::{Dir, WasiCtxBuilder};
+use wasmtime_wasi::{ambient_authority, Dir, WasiCtxBuilder};
 use wws_runtimes_manager::metadata::Runtime as RuntimeMetadata;
 use wws_store::Store;
 
@@ -90,10 +90,10 @@ impl Runtime for ExternalRuntime {
     /// Mount the source code in the WASI context so it can be
     /// processed by the engine
     fn prepare_wasi_ctx(&self, builder: WasiCtxBuilder) -> Result<WasiCtxBuilder> {
-        let source = fs::File::open(&self.store.folder)?;
+        let dir = Dir::open_ambient_dir(&self.store.folder, ambient_authority())?;
 
         Ok(builder
-            .preopened_dir(Dir::from_std_file(source), "/src")?
+            .preopened_dir(dir, "/src")?
             .args(&self.metadata.args)?)
     }
 

--- a/crates/runtimes/src/modules/javascript.rs
+++ b/crates/runtimes/src/modules/javascript.rs
@@ -3,10 +3,8 @@
 
 use crate::runtime::Runtime;
 use anyhow::Result;
-use std::path::Path;
-use std::{fs, path::PathBuf};
-use wasmtime_wasi::Dir;
-use wasmtime_wasi::WasiCtxBuilder;
+use std::path::{Path, PathBuf};
+use wasmtime_wasi::{ambient_authority, Dir, WasiCtxBuilder};
 use wws_store::Store;
 
 static JS_ENGINE_WASM: &[u8] =
@@ -48,8 +46,8 @@ impl Runtime for JavaScriptRuntime {
     /// Mount the source code in the WASI context so it can be
     /// processed by the engine
     fn prepare_wasi_ctx(&self, builder: WasiCtxBuilder) -> Result<WasiCtxBuilder> {
-        let source = fs::File::open(&self.store.folder)?;
-        Ok(builder.preopened_dir(Dir::from_std_file(source), "/src")?)
+        let dir = Dir::open_ambient_dir(&self.store.folder, ambient_authority())?;
+        Ok(builder.preopened_dir(dir, "/src")?)
     }
 
     /// Returns a reference to the Wasm module that should

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 use std::{collections::HashMap, path::Path};
 use stdio::Stdio;
 use wasmtime::{Engine, Linker, Module, Store};
-use wasmtime_wasi::{Dir, WasiCtxBuilder};
+use wasmtime_wasi::{ambient_authority, Dir, WasiCtxBuilder};
 use wws_config::Config as ProjectConfig;
 use wws_runtimes::{init_runtime, Runtime};
 
@@ -106,9 +106,8 @@ impl Worker {
         if let Some(folders) = self.config.folders.as_ref() {
             for folder in folders {
                 if let Some(base) = &self.path.parent() {
-                    let source = fs::File::open(base.join(&folder.from))?;
-                    wasi_builder =
-                        wasi_builder.preopened_dir(Dir::from_std_file(source), &folder.to)?;
+                    let dir = Dir::open_ambient_dir(base.join(&folder.from), ambient_authority())?;
+                    wasi_builder = wasi_builder.preopened_dir(dir, &folder.to)?;
                 } else {
                     // TODO: Revisit error management on #73
                     return Err(anyhow!("The worker couldn't be initialized"));


### PR DESCRIPTION
This PR fixes the issue when opening folders in Windows environments. Before, `wws` was using `fs::File::open` to open the directories for building the `WasiContext`. This approach worked properly on both Linux and MacOS, but was failing on Windows.

Now, `wws` open the directories with the [`Dir::open_ambient_dir` method](https://docs.rs/wasmtime-wasi/latest/wasmtime_wasi/sync/struct.Dir.html#method.open_ambient_dir) as the official [Wasmtime CLI does](https://github.com/bytecodealliance/wasmtime/blob/5b93cdb84def5fa7cb3ff823bc80216f19c296c5/src/commands/run.rs#L378).

From now on, these kind of errors will raise an error in the e2e tests (#134).

It closes #135 