### PR TITLE
Added error message and exposes WASM error message

### DIFF
--- a/crates/server/src/handlers/worker.rs
+++ b/crates/server/src/handlers/worker.rs
@@ -75,7 +75,7 @@ pub async fn handle_worker(req: HttpRequest, body: Bytes) -> HttpResponse {
                 .run(&req, &body_str, store, vars, stderr_file.get_ref())
             {
                 Ok(output) => (output, true),
-                Err(_) => (WasmOutput::failed(), false),
+                Err(_) => (eprintln!(), false),
             };
 
         let mut builder = HttpResponse::build(

--- a/crates/server/src/handlers/worker.rs
+++ b/crates/server/src/handlers/worker.rs
@@ -8,7 +8,7 @@ use actix_web::{
     web::{Bytes, Data},
     HttpRequest, HttpResponse,
 };
-use std::{fs::File, sync::RwLock, io::Write};
+use std::{fs::File, io::Write, sync::RwLock};
 use wws_router::Routes;
 use wws_worker::io::WasmOutput;
 
@@ -68,7 +68,7 @@ pub async fn handle_worker(req: HttpRequest, body: Bytes) -> HttpResponse {
             }
             None => None,
         };
-        
+
         let (handler_result, handler_success) =
             match route
                 .worker
@@ -77,16 +77,18 @@ pub async fn handle_worker(req: HttpRequest, body: Bytes) -> HttpResponse {
                 Ok(output) => (output, true),
                 Err(error) => {
                     if let Some(stderr_file) = stderr_file.get_ref() {
-                        if let Ok(mut stderr_file) = stderr_file.try_clone(){
-                            stderr_file.write_all(error.to_string().as_bytes()).expect("Failed to write error to stderr_file");
-                        }
-                        else{
+                        if let Ok(mut stderr_file) = stderr_file.try_clone() {
+                            stderr_file
+                                .write_all(error.to_string().as_bytes())
+                                .expect("Failed to write error to stderr_file");
+                        } else {
                             eprintln!("{}", error);
                         }
                     } else {
                         eprintln!("{}", error);
                     }
-                    (WasmOutput::failed(), false)},
+                    (WasmOutput::failed(), false)
+                }
             };
 
         let mut builder = HttpResponse::build(

--- a/crates/server/src/handlers/worker.rs
+++ b/crates/server/src/handlers/worker.rs
@@ -8,7 +8,7 @@ use actix_web::{
     web::{Bytes, Data},
     HttpRequest, HttpResponse,
 };
-use std::{fs::File, sync::RwLock};
+use std::{fs::File, sync::RwLock, io::Write};
 use wws_router::Routes;
 use wws_worker::io::WasmOutput;
 
@@ -68,15 +68,24 @@ pub async fn handle_worker(req: HttpRequest, body: Bytes) -> HttpResponse {
             }
             None => None,
         };
-
+        
         let (handler_result, handler_success) =
             match route
                 .worker
                 .run(&req, &body_str, store, vars, stderr_file.get_ref())
             {
                 Ok(output) => (output, true),
-                Err(e) => {
-                    eprintln!("{}", e);
+                Err(error) => {
+                    if let Some(stderr_file) = stderr_file.get_ref() {
+                        if let Ok(mut stderr_file) = stderr_file.try_clone(){
+                            stderr_file.write_all(error.to_string().as_bytes()).expect("Failed to write error to stderr_file");
+                        }
+                        else{
+                            eprintln!("{}", error);
+                        }
+                    } else {
+                        eprintln!("{}", error);
+                    }
                     (WasmOutput::failed(), false)},
             };
 

--- a/crates/server/src/handlers/worker.rs
+++ b/crates/server/src/handlers/worker.rs
@@ -75,7 +75,9 @@ pub async fn handle_worker(req: HttpRequest, body: Bytes) -> HttpResponse {
                 .run(&req, &body_str, store, vars, stderr_file.get_ref())
             {
                 Ok(output) => (output, true),
-                Err(_) => (eprintln!(), false),
+                Err(e) => {
+                    eprintln!("{}", e);
+                    (WasmOutput::failed(), false)},
             };
 
         let mut builder = HttpResponse::build(


### PR DESCRIPTION
Reference to this issue: https://github.com/vmware-labs/wasm-workers-server/issues/131

Before sending a generic error, wws must print the Wasm backtrace in the terminal. The stderr is configurable, so the stderr_file (Option<File>) may contain a file descriptor that should be used. If it's None, you can directly call eprintln! with the right message.

