### PR TITLE
fix: add missing certs to the wws container

### DIFF
--- a/image/Prebuilt.dockerfile
+++ b/image/Prebuilt.dockerfile
@@ -2,6 +2,10 @@
 # is mainly used to build the preview / release container images in
 # GitHub actions
 
+# Retrieve the certificates to install runtimes later on.
+FROM --platform=$TARGETPLATFORM bitnami/minideb:latest AS certs
+RUN install_packages ca-certificates
+
 # Build the final image
 FROM --platform=$TARGETPLATFORM scratch
 ARG TARGETPLATFORM
@@ -10,6 +14,7 @@ LABEL org.opencontainers.image.source=https://github.com/vmware-labs/wasm-worker
 LABEL org.opencontainers.image.description="Wasm Workers Server is a blazing-fast self-contained server that routes HTTP requests to workers in your filesystem. Everything run in a WebAssembly sandbox."
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --chmod=755 ./wws-$TARGETARCH /wws
 
 CMD ["/wws", "/app/", "--host", "0.0.0.0"]


### PR DESCRIPTION
Add local certificates so `wws` can install runtimes in the images we build from scratch. This was missing on the `preview` and tagged container we publish.

I already tested it on the [containderd-wasm-shims project](https://github.com/deislabs/containerd-wasm-shims/blob/main/images/wws-python/Dockerfile).

It fixes #120 