### PR TITLE
feat: add the initial administration panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "6.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73e721f488c353141288f223b599b4ae9303ecf3e62923f40a492f0634a4dc3"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22ce362f5561923889196595504317a4372b84210e6e335da529a65ea5452b5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.18",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512b0ab6853f7e14e3c8754acb43d6f748bb9ced66aa5915a6553ac8213f7731"
+dependencies = [
+ "sha2 0.10.6",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,6 +3770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wws-panel"
+version = "1.2.0"
+dependencies = [
+ "actix-web",
+ "mime_guess",
+ "rust-embed",
+]
+
+[[package]]
 name = "wws-project"
 version = "1.2.0"
 dependencies = [
@@ -3787,6 +3830,7 @@ dependencies = [
  "anyhow",
  "wws-api-manage",
  "wws-data-kv",
+ "wws-panel",
  "wws-router",
  "wws-worker",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
   "crates/config",
   "crates/data-kv",
   "crates/project",
+  "crates/panel",
   "crates/router",
   "crates/runtimes",
   "crates/server",
@@ -81,6 +82,7 @@ wws-server = { path = "./crates/server" }
 wws-store = { path = "./crates/store" }
 wws-worker = { path = "./crates/worker" }
 wws-project = { path = "./crates/project" }
+wws-panel = { path = "./crates/panel" }
 wws-api-manage = { path = "./crates/api-manage" }
 wws-api-manage-openapi = { path = "./crates/api-manage-openapi" }
 wasmtime = "6.0.2"

--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wws-panel"
+version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+rust-embed = "6.6.1"
+mime_guess = "2.0.4"
+actix-web = { workspace = true }

--- a/crates/panel/build.rs
+++ b/crates/panel/build.rs
@@ -1,0 +1,36 @@
+use std::{io::ErrorKind, process::Command};
+
+// Build the client admin panel.
+fn main() {
+    // First check if NPM is available in the system
+    match Command::new("npm").spawn() {
+        Ok(_) => {
+            Command::new("npm")
+                .current_dir("client")
+                .arg("install")
+                .status()
+                .expect("failed to execute process");
+
+            Command::new("npm")
+                .current_dir("client")
+                .args(["run", "build"])
+                .status()
+                .expect("failed to execute process");
+        }
+        Err(e) => {
+            if let ErrorKind::NotFound = e.kind() {
+                eprintln!("`npm` was not found in your system. Please, install NodeJS / NPM to build the admin panel.");
+                eprintln!("See: https://nodejs.dev/en/download/");
+            } else {
+                eprintln!(
+                    "There was an error when building the admin panel with NodeJS / NPM: {e}"
+                );
+            }
+        }
+    }
+
+    // Tell Cargo that if the given file changes, to rerun this build script.
+    println!("cargo:rerun-if-changed=client/src/*");
+    println!("cargo:rerun-if-changed=client/index.html");
+    println!("cargo:rerun-if-changed=client/vite.config.js");
+}

--- a/crates/panel/build.rs
+++ b/crates/panel/build.rs
@@ -31,6 +31,7 @@ fn main() {
 
     // Tell Cargo that if the given file changes, to rerun this build script.
     println!("cargo:rerun-if-changed=client/src/*");
+    println!("cargo:rerun-if-changed=client/public/*");
     println!("cargo:rerun-if-changed=client/index.html");
     println!("cargo:rerun-if-changed=client/vite.config.js");
 }

--- a/crates/panel/client/.gitignore
+++ b/crates/panel/client/.gitignore
@@ -1,0 +1,6 @@
+package-lock.json
+node_modules
+
+# Keep the dist folder to avoid errors when the client is not built.
+dist/*
+!dist/.gitkeep

--- a/crates/panel/client/index.html
+++ b/crates/panel/client/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Wasm Workers Server</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+
+<body cds-text="body">
+  <div id="app"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
+</html>

--- a/crates/panel/client/package.json
+++ b/crates/panel/client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wws-panel",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": "true",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@cds/city": "^1.1.0",
+    "@cds/core": "^6.4.2",
+    "@cds/react": "^6.4.2",
+    "react-router-dom": "^6.12.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "sass": "^1.62.1",
+    "vite": "^4.3.9"
+  }
+}

--- a/crates/panel/client/src/app.jsx
+++ b/crates/panel/client/src/app.jsx
@@ -1,0 +1,25 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import Header from './components/header';
+import Sidebar from './components/sidebar';
+import Content from './components/content';
+import { Outlet } from 'react-router-dom';
+
+function App() {
+  return (
+    <div cds-layout="vertical align:stretch">
+      <Header />
+      <div cds-layout="horizontal align:vertical-stretch wrap:none">
+        <Sidebar />
+        <div cds-layout="vertical align:stretch">
+          <Content>
+            <Outlet />
+          </Content>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default App

--- a/crates/panel/client/src/components/content.jsx
+++ b/crates/panel/client/src/components/content.jsx
@@ -1,0 +1,12 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import "./content.scss";
+
+const Content = ({ children }) => (
+    <div className="content" cds-layout="vertical gap:md p:xl">
+        {children}
+    </div>
+);
+
+export default Content;

--- a/crates/panel/client/src/components/content.scss
+++ b/crates/panel/client/src/components/content.scss
@@ -1,0 +1,8 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+.content {
+    &>*:first-child {
+        margin-top: 0;
+    }
+}

--- a/crates/panel/client/src/components/header.jsx
+++ b/crates/panel/client/src/components/header.jsx
@@ -1,0 +1,12 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import "./header.scss";
+
+const Header = () => (
+  <header className="header" cds-layout="p:md p@md:lg" cds-text="title">
+    Wasm Workers Server
+  </header>
+)
+
+export default Header;

--- a/crates/panel/client/src/components/header.scss
+++ b/crates/panel/client/src/components/header.scss
@@ -1,0 +1,7 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+header.header {
+    background: var(--cds-global-color-blue-1000);
+    color: var(--cds-global-color-gray-0);
+}

--- a/crates/panel/client/src/components/sidebar.jsx
+++ b/crates/panel/client/src/components/sidebar.jsx
@@ -1,0 +1,48 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CdsNavigation, CdsNavigationItem } from "@cds/react/navigation";
+import { CdsIcon } from "@cds/react/icon";
+import { ClarityIcons, cogIcon, cogIconName, fileIcon, fileIconName, homeIcon, homeIconName } from '@cds/core/icon';
+import { NavLink } from "react-router-dom";
+
+ClarityIcons.addIcons(cogIcon, fileIcon, homeIcon);
+
+import "./sidebar.scss";
+
+const items = [
+  {
+    name: "Server",
+    url: "/_panel/",
+    shape: homeIconName,
+  },
+  {
+    name: "Workers",
+    url: "/_panel/workers",
+    shape: cogIconName,
+  }
+];
+
+// Main submenu
+const Sidebar = () => (
+  <div className="sidebar">
+    <nav cds-layout="m-t:lg">
+      <CdsNavigation expanded>
+        {items.map(({ name, url, shape }, i) => (
+          <NavLink to={url}>
+            {({ isActive }) => (
+              <CdsNavigationItem active={isActive}>
+                <a>
+                  <CdsIcon shape={shape} size="sm" />
+                  {name}
+                </a>
+              </CdsNavigationItem>
+            )}
+          </NavLink>
+        ))}
+      </CdsNavigation>
+    </nav>
+  </div>
+);
+
+export default Sidebar;

--- a/crates/panel/client/src/components/sidebar.scss
+++ b/crates/panel/client/src/components/sidebar.scss
@@ -1,0 +1,26 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+.sidebar {
+    display: flex;
+    flex-direction: column;
+    // 71px from the header
+    min-height: calc(100vh - 71px);
+    position: relative;
+    width: 12rem;
+
+    // Add a border with after due to collision with
+    // the nav items.
+    &:after {
+        content: "";
+        background-color: var(--cds-alias-status-disabled-tint);
+        height: 100%;
+        width: 1px;
+        position: absolute;
+        right: -1px;
+    }
+
+    a {
+        text-decoration: none;
+    }
+}

--- a/crates/panel/client/src/components/workerCard.jsx
+++ b/crates/panel/client/src/components/workerCard.jsx
@@ -1,0 +1,41 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CdsCard } from "@cds/react/card";
+import { CdsDivider } from "@cds/react/divider";
+import { CdsIcon } from "@cds/react/icon";
+import { CdsButton } from "@cds/react/button";
+import { ClarityIcons, linkIcon, linkIconName, eyeIcon, eyeIconName } from '@cds/core/icon';
+import { Link } from "react-router-dom";
+
+ClarityIcons.addIcons(linkIcon, eyeIcon);
+
+const WorkerCard = ({ worker }) => {
+  return <CdsCard>
+    <div className="worker-card">
+      <h3 cds-layout="m-t:xs m-b:md" cds-text="section">{worker.name}</h3>
+      <CdsDivider cds-card-remove-margin />
+      <p>
+        <b>Endpoint:</b> {worker.path}
+      </p>
+      <p>
+        <b>Filepath:</b> {worker.filepath}
+      </p>
+      <CdsDivider cds-card-remove-margin />
+      <div cds-layout="horizontal m-t:md m-b:xxs gap:sm align:right">
+        <Link to={worker.id}>
+          <CdsButton action="flat-inline">
+            <CdsIcon shape={eyeIconName} size="sm" /> Details
+          </CdsButton>
+        </Link>
+        <a href={worker.path} target="_blank">
+          <CdsButton action="flat-inline">
+            <CdsIcon shape={linkIconName} size="sm" /> View
+          </CdsButton>
+        </a>
+      </div>
+    </div>
+  </CdsCard>
+};
+
+export default WorkerCard;

--- a/crates/panel/client/src/main.jsx
+++ b/crates/panel/client/src/main.jsx
@@ -1,0 +1,15 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import router from "./router";
+
+import './main.scss';
+
+ReactDOM.createRoot(document.getElementById('app')).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>,
+)

--- a/crates/panel/client/src/main.scss
+++ b/crates/panel/client/src/main.scss
@@ -1,0 +1,20 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+@import 'modern-normalize/modern-normalize.css';
+@import '@cds/core/global.min.css';
+@import '@cds/city/css/bundles/default.min.css';
+@import '@cds/core/styles/theme.dark.min.css';
+@import '@cds/core/table/table.min.css';
+
+// Layout
+#app,
+.main-container {
+    min-height: 100vh;
+}
+
+// Helper methods
+ul.clear {
+    margin: 0;
+    padding: 0;
+}

--- a/crates/panel/client/src/router.jsx
+++ b/crates/panel/client/src/router.jsx
@@ -1,0 +1,41 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Outlet,
+  createBrowserRouter,
+} from "react-router-dom";
+
+import App from "./app";
+import Home from "./routes/home";
+import Workers from "./routes/workers";
+import Worker from "./routes/worker";
+
+const router = createBrowserRouter([
+  {
+    path: "/_panel/",
+    element: <App />,
+    children: [
+      {
+        index: true,
+        element: <Home />,
+      },
+      {
+        path: "workers",
+        element: <Outlet />,
+        children: [
+          {
+            index: true,
+            element: <Workers />
+          },
+          {
+            path: ":id",
+            element: <Worker />
+          }
+        ]
+      },
+    ]
+  },
+]);
+
+export default router;

--- a/crates/panel/client/src/routes/home.jsx
+++ b/crates/panel/client/src/routes/home.jsx
@@ -1,0 +1,54 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react'
+import { CdsTag } from "@cds/react/tag";
+import { CdsProgressCircle } from "@cds/react/progress-circle";
+import { CdsCard } from "@cds/react/card";
+import { CdsIcon } from "@cds/react/icon";
+import { CdsButton } from "@cds/react/button";
+import { CdsDivider } from "@cds/react/divider";
+import { ClarityIcons, eyeIcon, eyeIconName } from '@cds/core/icon';
+import { Link } from "react-router-dom";
+
+ClarityIcons.addIcons(eyeIcon);
+
+const Home = () => {
+  const [result, setResult] = useState(undefined);
+
+  useEffect(() => {
+    fetch("/_api/v0/workers")
+      .then(res => res.json())
+      .then(json => setResult(json));
+  }, []);
+
+  return <>
+    <h2 cds-text="heading">Server</h2>
+    {result === undefined ? (
+      <CdsProgressCircle size="xl" />
+    ) : (
+      <>
+        <CdsTag readonly status="success">Running</CdsTag>
+        <div cds-layout="grid cols:auto gap:lg align:left">
+          <CdsCard>
+            <h3 cds-layout="m-t:xs m-b:md" cds-text="section">Workers</h3>
+            <CdsDivider cds-card-remove-margin />
+            <p cds-layout="m-t:lg m-b:lg" cds-text="display right">
+              <b>{result.length}</b>
+            </p>
+            <CdsDivider cds-card-remove-margin />
+            <div cds-layout="horizontal m-t:md m-b:xxs gap:sm align:right">
+              <Link to="workers">
+                <CdsButton action="flat-inline">
+                  <CdsIcon shape={eyeIconName} size="sm" /> See workers
+                </CdsButton>
+              </Link>
+            </div>
+          </CdsCard>
+        </div>
+      </>
+    )}
+  </>
+};
+
+export default Home;

--- a/crates/panel/client/src/routes/worker.jsx
+++ b/crates/panel/client/src/routes/worker.jsx
@@ -1,0 +1,99 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react'
+import { CdsProgressCircle } from "@cds/react/progress-circle";
+import { useParams } from 'react-router-dom';
+
+const Worker = () => {
+  const [result, setResult] = useState(undefined);
+  let params = useParams();
+
+  useEffect(() => {
+    fetch(`/_api/v0/workers/${params.id}`)
+      .then(res => res.json())
+      .then(json => setResult(json));
+  }, []);
+
+  return <>
+    <h2 cds-text="heading">Worker information</h2>
+    <p>ID: {params.id}</p>
+    {result === undefined ? (
+      <CdsProgressCircle size="xl" />
+    ) : (
+      <>
+        <h3 cds-text="section">Key / Value store</h3>
+        <table cds-table="border:row border:outside" cds-text="left">
+          <thead>
+            <tr>
+              <th>Namespace</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>{result.data.kv ? result.data.kv : "-"}</td>
+            </tr>
+          </tbody>
+        </table>
+        <h3 cds-layout="m-t:md" cds-text="section">Environment variables</h3>
+        <table cds-table="border:row border:outside" cds-text="left">
+          <thead>
+            <tr>
+              <th>Variable</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.keys(result.vars).length == 0 ? (
+              <tr>
+                <td>
+                  -
+                </td>
+                <td>
+                  -
+                </td>
+              </tr>
+            ) : (
+              Object.keys(result.vars).map((k, i) => (
+                <tr key={i}>
+                  <td>{k}</td>
+                  <td>{result.vars[k]}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+        <h3 cds-layout="m-t:md" cds-text="section">Mount folders</h3>
+        <table cds-table="border:row border:outside" cds-text="left">
+          <thead>
+            <tr>
+              <th>From</th>
+              <th>To</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.folders.length == 0 ? (
+              <tr>
+                <td>
+                  -
+                </td>
+                <td>
+                  -
+                </td>
+              </tr>
+            ) : (
+              result.folders.map((f, i) => (
+                <tr key={i}>
+                  <td>{f.from}</td>
+                  <td>{f.to}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </>
+    )}
+  </>
+}
+
+export default Worker;

--- a/crates/panel/client/src/routes/workers.jsx
+++ b/crates/panel/client/src/routes/workers.jsx
@@ -1,0 +1,31 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react'
+import WorkerCard from "../components/workerCard";
+import { CdsProgressCircle } from "@cds/react/progress-circle";
+
+const Workers = () => {
+  const [result, setResult] = useState(undefined);
+
+  useEffect(() => {
+    fetch("/_api/v0/workers")
+      .then(res => res.json())
+      .then(json => setResult(json));
+  }, []);
+
+  return <>
+    <h2 cds-text="heading">Workers</h2>
+    {result === undefined ? (
+      <CdsProgressCircle size="xl" />
+    ) : (
+      <div cds-layout="grid cols:auto gap:lg align:left">
+        {result.map((p, i) => (
+          <WorkerCard worker={p} key={i} />
+        ))}
+      </div>
+    )}
+  </>
+}
+
+export default Workers;

--- a/crates/panel/client/vite.config.js
+++ b/crates/panel/client/vite.config.js
@@ -1,0 +1,16 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    plugins: [react()],
+    base: "/_panel/",
+    server: {
+        proxy: {
+            '/_api': 'http://localhost:8080',
+        }
+    }
+})

--- a/crates/panel/src/handlers/mod.rs
+++ b/crates/panel/src/handlers/mod.rs
@@ -1,0 +1,1 @@
+pub mod panel;

--- a/crates/panel/src/handlers/panel.rs
+++ b/crates/panel/src/handlers/panel.rs
@@ -1,0 +1,30 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use actix_web::{
+    web::{self},
+    HttpResponse, Responder,
+};
+use mime_guess::from_path;
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "client/dist/"]
+struct Asset;
+
+/// Find the static assets of the administration panel
+#[actix_web::get("/_panel{_:.*}")]
+pub async fn handle_static_panel(path: web::Path<String>) -> impl Responder {
+    let path = if path.len() == 0 {
+        "index.html"
+    } else {
+        path.as_str().strip_prefix('/').unwrap()
+    };
+
+    match Asset::get(path) {
+        Some(content) => HttpResponse::Ok()
+            .content_type(from_path(path).first_or_octet_stream().as_ref())
+            .body(content.data.into_owned()),
+        None => HttpResponse::NotFound().body("404 Not Found"),
+    }
+}

--- a/crates/panel/src/lib.rs
+++ b/crates/panel/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use actix_web::web::ServiceConfig;
+
+mod handlers;
+
+/// Add the administration panel HTTP handlers to an existing
+/// Actix application.
+pub fn config_panel_handlers(cfg: &mut ServiceConfig) {
+    cfg.service(handlers::panel::handle_static_panel);
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -13,4 +13,5 @@ wws-api-manage = { workspace = true }
 wws-data-kv = { workspace = true }
 wws-router = { workspace = true }
 wws-worker = { workspace = true }
+wws-panel = { workspace = true }
 actix-files = "0.6.2"

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -19,6 +19,7 @@ use std::path::Path;
 use std::sync::RwLock;
 use wws_api_manage::config_manage_api_handlers;
 use wws_data_kv::KV;
+use wws_panel::config_panel_handlers;
 use wws_router::Routes;
 
 #[derive(Default)]
@@ -65,6 +66,7 @@ pub async fn serve(
 
         // Configure panel
         if panel {
+            app = app.configure(config_panel_handlers);
             app = app.configure(config_manage_api_handlers);
         }
 


### PR DESCRIPTION
As Wasm Workers Server is evolving, we want to start adding an UI to start managing it. I'm really happy to open this PR as an initial version of that UI 😄. This admin panel is enabled via the `--enable-panel` flag and the UI looks like this:

```
$ wws https://github.com/vmware-labs/wasm-workers-server.git --git-folder "examples/python-basic" -i --enable-panel
⚙️  Preparing the project from: https://github.com/vmware-labs/wasm-workers-server.git
⚙️  Checking local configuration...
🚀 Installing: wasmlabs - python / 3.11.1+20230217
✅ Done
⚙️  Loading routes from: /tmp/dd21e3cd6d0f515301e1c7070e562af06074d9e8d10566179f97dba47e74cec9/examples/python-basic
⏳ Loading workers from 1 routes...
✅ Workers loaded in 489.699125ms.
    - http://127.0.0.1:8080/
      => /tmp/dd21e3cd6d0f515301e1c7070e562af06074d9e8d10566179f97dba47e74cec9/examples/python-basic/index.py
🎛️  The admin panel is available at http://127.0.0.1:8080/_panel/
🚀 Start serving requests at http://127.0.0.1:8080
```
![Home page showing a card with the number of current workers](https://github.com/vmware-labs/wasm-workers-server/assets/4056725/c92b8b65-3fa3-41ac-a21c-b7f71e03c89f)
![List all the current workers in the server](https://github.com/vmware-labs/wasm-workers-server/assets/4056725/5cfafc43-1f0b-4be0-acd5-fc7a9c4bc01a)
![Show the details of a specific worker](https://github.com/vmware-labs/wasm-workers-server/assets/4056725/1393046e-e881-4fb0-bea0-29862164ceb1)

In the future, we will start adding more features to it.

### Development

Currently, the UI is shipped as a crate (panel) and integrated in the main project. The client uses [React](https://react.dev/), [Clarity Core](https://core.clarity.design/) and [Vite](vitejs.dev/). To develop this UI you need to install NodeJS and NPM in your environment.

Cargo automatically builds the UI based from the build.rs file. If `npm` is not available, the build pipeline will success, although the panel won't be available. We designed this way to avoid breaking build pipelines that don't relate to the client when `node` / `npm` is not available.

### Integration

To integrate the compiled admin panel into the project, I used the [rust-embed](https://github.com/pyrossh/rust-embed) project. It automatically picks the files in a folder, embed them in the binary and provide an API to get the file content. With this approach we keep the server as a single-binary that it's easier to distribute.

It closes #153