### PR TITLE
fix: install openssl@3 when building wws in actions

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -70,8 +70,8 @@ jobs:
       if: ${{ matrix.build == 'macos' && matrix.arch == 'aarch64' }}
       run: |
         brew install pkg-config-wrapper
-        brew fetch --force --bottle-tag=arm64_monterrey openssl@3
-        brew install $(brew --cache --bottle-tag=arm64_monterrey openssl@3)
+        brew fetch --force --bottle-tag=arm64_monterey openssl@3
+        brew install $(brew --cache --bottle-tag=arm64_monterey openssl@3)
     - name: Install deps (Linux)
       if: ${{ matrix.build == 'linux' }}
       run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -71,7 +71,8 @@ jobs:
       run: |
         brew install pkg-config-wrapper
         brew fetch --force --bottle-tag=arm64_monterey openssl@3
-        brew install $(brew --cache --bottle-tag=arm64_monterey openssl@3)
+        brew install --overwrite $(brew --cache --bottle-tag=arm64_monterey openssl@3)
+        echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
     - name: Install deps (Linux)
       if: ${{ matrix.build == 'linux' }}
       run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -21,36 +21,42 @@ jobs:
             platform: unknown-linux-musl
             cross: false
             name: linux-musl
+            features: --features vendored-openssl
           - build: linux
             arch: aarch64
             os: ubuntu-latest
             platform: unknown-linux-musl
             cross: true
             name: linux-musl
+            features: --features vendored-openssl
           - build: windows
             arch: x86_64
             os: windows-latest
             platform: pc-windows-msvc
             cross: false
             name: pc-windows
+            features:
           - build: windows
             arch: aarch64
             os: windows-latest
             platform: pc-windows-msvc
             cross: false
             name: pc-windows
+            features:
           - build: macos
             arch: x86_64
             os: macos-latest
             platform: apple-darwin
             cross: false
             name: macos-darwin
+            features:
           - build: macos
             arch: aarch64
             os: macos-latest
             platform: apple-darwin
-            cross: false
+            cross: true
             name: macos-darwin
+            features: --features vendored-openssl
     runs-on: ${{ matrix.os }}
     env:
       # This variable can be overriden with `cross` for builds that
@@ -66,22 +72,13 @@ jobs:
     - name: Install target
       if: matrix.cross == false
       run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
-    - name: Install deps (macOS arm64)
-      if: ${{ matrix.build == 'macos' && matrix.arch == 'aarch64' }}
-      run: |
-        brew install pkg-config-wrapper
-        brew fetch --force --bottle-tag=arm64_monterey openssl@3
-        brew install --overwrite $(brew --cache --bottle-tag=arm64_monterey openssl@3)
-        echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
-        echo "OPENSSL_LIB_DIR=$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
-        echo "OPENSSL_INCLUDE_DIR=$(brew --prefix openssl@3)/include" >> $GITHUB_ENV
     - name: Install deps (Linux)
       if: ${{ matrix.build == 'linux' }}
       run: |
         sudo apt-get update
         sudo apt-get install musl-tools
     - name: Build
-      run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{ matrix.platform }}
+      run: ${{env.CARGO}} build --verbose --release --target=${{ matrix.arch }}-${{ matrix.platform }} ${{ matrix.features }}
     - name: Tarball
       shell: bash
       run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
+  # FOR TESTING (REMOVE IT BEFORE MERGING THE PR)
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   build:
@@ -63,7 +66,10 @@ jobs:
     - name: Install target
       if: matrix.cross == false
       run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
-    - name: Install deps
+    - name: Install deps (macOS)
+      if: ${{ matrix.build == 'macos' }}
+      run: brew install openssl@3
+    - name: Install deps (Linux)
       if: ${{ matrix.build == 'linux' }}
       run: |
         sudo apt-get update

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -68,7 +68,7 @@ jobs:
       run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
     - name: Install deps (macOS)
       if: ${{ matrix.build == 'macos' }}
-      run: brew install openssl@3
+      run: brew install pkg-config-wrapper
     - name: Install deps (Linux)
       if: ${{ matrix.build == 'linux' }}
       run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -66,9 +66,12 @@ jobs:
     - name: Install target
       if: matrix.cross == false
       run: rustup target add ${{ matrix.arch }}-${{ matrix.platform }}
-    - name: Install deps (macOS)
-      if: ${{ matrix.build == 'macos' }}
-      run: brew install pkg-config-wrapper
+    - name: Install deps (macOS arm64)
+      if: ${{ matrix.build == 'macos' && matrix.arch == 'aarch64' }}
+      run: |
+        brew install pkg-config-wrapper
+        brew fetch --force --bottle-tag=arm64_monterrey openssl@3
+        brew install $(brew --cache --bottle-tag=arm64_monterrey openssl@3)
     - name: Install deps (Linux)
       if: ${{ matrix.build == 'linux' }}
       run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
-  # FOR TESTING (REMOVE IT BEFORE MERGING THE PR)
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -73,6 +73,8 @@ jobs:
         brew fetch --force --bottle-tag=arm64_monterey openssl@3
         brew install --overwrite $(brew --cache --bottle-tag=arm64_monterey openssl@3)
         echo "OPENSSL_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
+        echo "OPENSSL_LIB_DIR=$(brew --prefix openssl@3)/lib" >> $GITHUB_ENV
+        echo "OPENSSL_INCLUDE_DIR=$(brew --prefix openssl@3)/include" >> $GITHUB_ENV
     - name: Install deps (Linux)
       if: ${{ matrix.build == 'linux' }}
       run: |

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -54,7 +54,7 @@ jobs:
             arch: aarch64
             os: macos-latest
             platform: apple-darwin
-            cross: true
+            cross: false
             name: macos-darwin
             features: --features vendored-openssl
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3148,7 +3148,6 @@ dependencies = [
  "anyhow",
  "clap 4.3.4",
  "env_logger 0.9.3",
- "openssl",
  "prettytable-rs",
  "reqwest",
  "wws-config",
@@ -3884,6 +3883,7 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "git2",
+ "openssl",
  "path-slash",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,11 +36,8 @@ wws-project = { workspace = true }
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["blocking"] }
 
-[target.x86_64-unknown-linux-musl.dependencies]
-openssl = { version = "=0.10.55", features = ["vendored"] }
-
-[target.aarch64-unknown-linux-musl.dependencies]
-openssl = { version = "=0.10.55", features = ["vendored"] }
+[features]
+vendored-openssl = ["wws-project/vendored-openssl"]
 
 [workspace]
 members = [
@@ -89,3 +86,4 @@ wasmtime = "10.0.1"
 wasmtime-wasi = "10.0.1"
 wasi-common = "10.0.1"
 path-slash = "0.2.1"
+openssl = { version = "=0.10.55" }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -12,11 +12,12 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 wws-store = { workspace = true }
-openssl = { workspace = true }
 url = "2.3.1"
 sha256 = "1.1.1"
 reqwest = "0.11"
 git2 = "0.17.2"
+# Not all platforms require OpenSSL
+openssl = { workspace = true, optional = true }
 
 [features]
 vendored-openssl = ["openssl/vendored"]

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -12,10 +12,14 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 wws-store = { workspace = true }
+openssl = { workspace = true }
 url = "2.3.1"
 sha256 = "1.1.1"
 reqwest = "0.11"
 git2 = "0.17.2"
+
+[features]
+vendored-openssl = ["openssl/vendored"]
 
 [dev-dependencies]
 path-slash = { workspace = true }


### PR DESCRIPTION
When releasing `wws` v1.3, the `artifacts` [action was failing for macOS](https://github.com/vmware-labs/wasm-workers-server/actions/runs/5353724410/jobs/9709914752). The issue was related to the `openssl` crate upgrade on #132.

This is the error message from the job:

```
  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/sfackler/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-apple-darwin
  $TARGET = aarch64-apple-darwin
  openssl-sys = 0.9.90
``` 

Based on the `openssl` crate documentation, [you need to install OpenSSL to build it](https://docs.rs/openssl/latest/openssl/#automatic). I assume the action runner was installing and old version that it's no longer valid for the crate and we need to explicitly install the latest one.