### PR TITLE
feat: allow configuring the http_requests via TOML

### DIFF
--- a/crates/api-manage/src/models/worker_config.rs
+++ b/crates/api-manage/src/models/worker_config.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use serde::Serialize;
 use utoipa::ToSchema;
 use wws_worker::{
-    config::{ConfigData, Folder},
+    features::{data::ConfigData, folders::Folder},
     Worker,
 };
 

--- a/crates/worker/src/bindings/http.rs
+++ b/crates/worker/src/bindings/http.rs
@@ -16,6 +16,22 @@ pub struct HttpBindings {
     pub http_config: HttpRequestsConfig,
 }
 
+/// Implement the conversion between HttpMethod and
+/// http::Method
+impl From<HttpMethod> for reqwest::Method {
+    fn from(value: HttpMethod) -> Self {
+        match value {
+            HttpMethod::Get => Method::GET,
+            HttpMethod::Post => Method::POST,
+            HttpMethod::Put => Method::PUT,
+            HttpMethod::Patch => Method::PATCH,
+            HttpMethod::Delete => Method::DELETE,
+            HttpMethod::Options => Method::OPTIONS,
+            HttpMethod::Head => Method::HEAD,
+        }
+    }
+}
+
 /// Map the reqwest error to a known http-error
 /// HttpError comes from the HTTP bindings
 impl From<reqwest::Error> for HttpError {
@@ -49,15 +65,7 @@ impl Http for HttpBindings {
             error: HttpError::InvalidRequest,
             message: e.to_string(),
         })?;
-        let method = match req.method {
-            HttpMethod::Get => Method::GET,
-            HttpMethod::Post => Method::POST,
-            HttpMethod::Put => Method::PUT,
-            HttpMethod::Patch => Method::PATCH,
-            HttpMethod::Delete => Method::DELETE,
-            HttpMethod::Options => Method::OPTIONS,
-            HttpMethod::Head => Method::HEAD,
-        };
+        let method: Method = req.method.into();
 
         // Check if the request is allowed
         if uri.host().is_some()

--- a/crates/worker/src/bindings/http.rs
+++ b/crates/worker/src/bindings/http.rs
@@ -76,7 +76,7 @@ impl Http for HttpBindings {
         }
 
         if uri.scheme().is_some()
-            && (self.http_config.force_https && uri.scheme_str().unwrap() != "https")
+            && (!self.http_config.allow_http && uri.scheme_str().unwrap() == "http")
         {
             return Err(HttpRequestError {
                 error: HttpError::NotAllowed,

--- a/crates/worker/src/bindings/http.rs
+++ b/crates/worker/src/bindings/http.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::features::http_requests::HttpRequests;
+use actix_web::http::Uri;
 use reqwest::Method;
 use tokio::runtime::Builder;
 
@@ -10,7 +12,9 @@ use http::{Http, HttpError, HttpMethod, HttpRequest, HttpRequestError, HttpRespo
 
 pub use http::add_to_linker;
 
-pub struct HttpBindings {}
+pub struct HttpBindings {
+    pub http_config: HttpRequests,
+}
 
 /// Map the reqwest error to a known http-error
 /// HttpError comes from the HTTP bindings
@@ -39,8 +43,59 @@ impl Http for HttpBindings {
     ) -> Result<HttpResponse, HttpRequestError> {
         // Create local variables from the request
         let mut headers = Vec::new();
-        let uri = req.uri.to_string();
+        let url = req.uri.to_string();
         let body = req.body.unwrap_or(&[]).to_vec();
+        let uri = url.parse::<Uri>().map_err(|e| HttpRequestError {
+            error: HttpError::InvalidRequest,
+            message: e.to_string(),
+        })?;
+        let method = match req.method {
+            HttpMethod::Get => Method::GET,
+            HttpMethod::Post => Method::POST,
+            HttpMethod::Put => Method::PUT,
+            HttpMethod::Patch => Method::PATCH,
+            HttpMethod::Delete => Method::DELETE,
+            HttpMethod::Options => Method::OPTIONS,
+            HttpMethod::Head => Method::HEAD,
+        };
+
+        // Check if the request is allowed
+        if uri.host().is_some()
+            && !self
+                .http_config
+                .allowed_hosts
+                .contains(&uri.host().unwrap().to_string())
+        {
+            return Err(HttpRequestError {
+                error: HttpError::NotAllowed,
+                message: format!(
+                    "The host '{}' is not allowed for this worker. Please, update the worker configuration.",
+                    uri.host().unwrap()
+                ),
+            });
+        }
+
+        if uri.scheme().is_some()
+            && (self.http_config.force_https && uri.scheme_str().unwrap() != "https")
+        {
+            return Err(HttpRequestError {
+                error: HttpError::NotAllowed,
+                message:
+                    "The URI must use HTTPS. You can allow http requests in the worker configuration".to_string()
+            });
+        }
+
+        if !self
+            .http_config
+            .allowed_methods
+            .contains(&method.to_string())
+        {
+            return Err(HttpRequestError {
+                error: HttpError::NotAllowed,
+                message:
+                    format!("The method '{}' is not allowed for this worker. Please, update the configuration.", method.as_str())
+            });
+        }
 
         for (key, value) in req.headers {
             headers.push((key.to_string(), value.to_string()));
@@ -55,17 +110,7 @@ impl Http for HttpBindings {
                 .block_on(async {
                     let client = reqwest::Client::new();
 
-                    let method = match req.method {
-                        HttpMethod::Get => Method::GET,
-                        HttpMethod::Post => Method::POST,
-                        HttpMethod::Put => Method::PUT,
-                        HttpMethod::Patch => Method::PATCH,
-                        HttpMethod::Delete => Method::DELETE,
-                        HttpMethod::Options => Method::OPTIONS,
-                        HttpMethod::Head => Method::HEAD,
-                    };
-
-                    let mut builder = client.request(method, uri);
+                    let mut builder = client.request(method, url);
 
                     for (key, value) in headers {
                         builder = builder.header(key, value);

--- a/crates/worker/src/bindings/http.rs
+++ b/crates/worker/src/bindings/http.rs
@@ -1,7 +1,7 @@
 // Copyright 2023 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::features::http_requests::HttpRequests;
+use crate::features::http_requests::HttpRequestsConfig;
 use actix_web::http::Uri;
 use reqwest::Method;
 use tokio::runtime::Builder;
@@ -13,7 +13,7 @@ use http::{Http, HttpError, HttpMethod, HttpRequest, HttpRequestError, HttpRespo
 pub use http::add_to_linker;
 
 pub struct HttpBindings {
-    pub http_config: HttpRequests,
+    pub http_config: HttpRequestsConfig,
 }
 
 /// Map the reqwest error to a known http-error

--- a/crates/worker/src/config.rs
+++ b/crates/worker/src/config.rs
@@ -1,6 +1,8 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2022-2023 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::features::http_requests::HttpRequests;
+use crate::features::{data::ConfigData, folders::Folder};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Deserializer};
 use std::collections::HashMap;
@@ -9,6 +11,13 @@ use std::{env, fs};
 use toml::from_str;
 use wws_data_kv::KVConfigData;
 
+/// List all available features for a worker
+#[derive(Deserialize, Clone, Default)]
+pub struct Features {
+    /// Allow to perform http requests from a worker
+    pub http_requests: HttpRequests,
+}
+
 /// Workers configuration. These files are optional when no configuration change is required.
 #[derive(Deserialize, Clone, Default)]
 pub struct Config {
@@ -16,6 +25,9 @@ pub struct Config {
     pub name: Option<String>,
     /// Mandatory version of the file
     pub version: String,
+    /// List of features. By default, all will be inactive
+    #[serde(default)]
+    pub features: Features,
     /// Optional data configuration
     pub data: Option<ConfigData>,
     /// Optional folders
@@ -23,13 +35,6 @@ pub struct Config {
     /// Optional environment configuration
     #[serde(deserialize_with = "read_environment_variables", default)]
     pub vars: HashMap<String, String>,
-}
-
-/// Configure a data plugin for the worker
-#[derive(Deserialize, Clone, Default)]
-pub struct ConfigData {
-    /// Creates a Key/Value store associated to the given worker
-    pub kv: Option<KVConfigData>,
 }
 
 impl Config {
@@ -106,44 +111,6 @@ where
             }
             None => Ok(HashMap::new()),
         },
-        Err(err) => Err(err),
-    }
-}
-
-/// A folder to mount in the worker
-#[derive(Deserialize, Clone, Default)]
-pub struct Folder {
-    /// Local folder
-    #[serde(deserialize_with = "deserialize_path", default)]
-    pub from: PathBuf,
-    /// Mount point
-    pub to: String,
-}
-
-/// Deserialize a valid path for the given platform. This method checks and
-/// split the path by the different separators and join the final path
-/// using the current OS requirements.
-fn deserialize_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let result: Result<String, D::Error> = Deserialize::deserialize(deserializer);
-
-    match result {
-        Ok(value) => {
-            let split = if value.contains('/') {
-                // Unix separator
-                value.split('/')
-            } else {
-                // Windows separator
-                value.split('\\')
-            };
-
-            Ok(split.fold(PathBuf::new(), |mut acc, el| {
-                acc.push(el);
-                acc
-            }))
-        }
         Err(err) => Err(err),
     }
 }

--- a/crates/worker/src/config.rs
+++ b/crates/worker/src/config.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::features::http_requests::HttpRequests;
+use crate::features::http_requests::HttpRequestsConfig;
 use crate::features::{data::ConfigData, folders::Folder};
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Deserializer};
@@ -15,7 +15,7 @@ use wws_data_kv::KVConfigData;
 #[derive(Deserialize, Clone, Default)]
 pub struct Features {
     /// Allow to perform http requests from a worker
-    pub http_requests: HttpRequests,
+    pub http_requests: HttpRequestsConfig,
 }
 
 /// Workers configuration. These files are optional when no configuration change is required.

--- a/crates/worker/src/features/data.rs
+++ b/crates/worker/src/features/data.rs
@@ -1,0 +1,12 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+use wws_data_kv::KVConfigData;
+
+/// Configure a data plugin for the worker
+#[derive(Deserialize, Clone, Default)]
+pub struct ConfigData {
+    /// Creates a Key/Value store associated to the given worker
+    pub kv: Option<KVConfigData>,
+}

--- a/crates/worker/src/features/folders.rs
+++ b/crates/worker/src/features/folders.rs
@@ -1,0 +1,43 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Deserializer};
+use std::path::PathBuf;
+
+/// A folder to mount in the worker
+#[derive(Deserialize, Clone, Default)]
+pub struct Folder {
+    /// Local folder
+    #[serde(deserialize_with = "deserialize_path", default)]
+    pub from: PathBuf,
+    /// Mount point
+    pub to: String,
+}
+
+/// Deserialize a valid path for the given platform. This method checks and
+/// split the path by the different separators and join the final path
+/// using the current OS requirements.
+fn deserialize_path<'de, D>(deserializer: D) -> Result<PathBuf, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let result: Result<String, D::Error> = Deserialize::deserialize(deserializer);
+
+    match result {
+        Ok(value) => {
+            let split = if value.contains('/') {
+                // Unix separator
+                value.split('/')
+            } else {
+                // Windows separator
+                value.split('\\')
+            };
+
+            Ok(split.fold(PathBuf::new(), |mut acc, el| {
+                acc.push(el);
+                acc
+            }))
+        }
+        Err(err) => Err(err),
+    }
+}

--- a/crates/worker/src/features/http_requests.rs
+++ b/crates/worker/src/features/http_requests.rs
@@ -11,14 +11,14 @@ pub struct HttpRequests {
     /// List of allowed HTTP methods for the worker
     #[serde(default = "default_methods")]
     pub allowed_methods: Vec<String>,
-    /// Force an SSL connection in all hosts
-    #[serde(default = "default_true")]
-    pub force_https: bool,
+    /// Allow HTTP requests
+    #[serde(default = "default_false")]
+    pub allow_http: bool,
 }
 
-/// Enable the configuration parameter by default
-fn default_true() -> bool {
-    true
+/// Turn the given configuration false by default
+fn default_false() -> bool {
+    false
 }
 
 /// It allows only basic methods by default

--- a/crates/worker/src/features/http_requests.rs
+++ b/crates/worker/src/features/http_requests.rs
@@ -3,27 +3,29 @@
 
 use serde::Deserialize;
 
-#[derive(Deserialize, Clone, Default)]
-pub struct HttpRequests {
+#[derive(Deserialize, Clone)]
+#[serde(default)]
+pub struct HttpRequestsConfig {
     /// List of allowed domains to perform the calls
-    #[serde(default)]
     pub allowed_hosts: Vec<String>,
     /// List of allowed HTTP methods for the worker
-    #[serde(default = "default_methods")]
     pub allowed_methods: Vec<String>,
     /// Allow HTTP requests
-    #[serde(default)]
     pub allow_http: bool,
 }
 
-
-/// It allows only basic methods by default
-fn default_methods() -> Vec<String> {
-    Vec::from([
-        String::from("GET"),
-        String::from("POST"),
-        String::from("PUT"),
-        String::from("PATCH"),
-        String::from("DELETE"),
-    ])
+impl Default for HttpRequestsConfig {
+    fn default() -> Self {
+        Self {
+            allowed_hosts: Vec::default(),
+            allowed_methods: Vec::from([
+                String::from("GET"),
+                String::from("POST"),
+                String::from("PUT"),
+                String::from("PATCH"),
+                String::from("DELETE"),
+            ]),
+            allow_http: false,
+        }
+    }
 }

--- a/crates/worker/src/features/http_requests.rs
+++ b/crates/worker/src/features/http_requests.rs
@@ -12,14 +12,10 @@ pub struct HttpRequests {
     #[serde(default = "default_methods")]
     pub allowed_methods: Vec<String>,
     /// Allow HTTP requests
-    #[serde(default = "default_false")]
+    #[serde(default)]
     pub allow_http: bool,
 }
 
-/// Turn the given configuration false by default
-fn default_false() -> bool {
-    false
-}
 
 /// It allows only basic methods by default
 fn default_methods() -> Vec<String> {

--- a/crates/worker/src/features/http_requests.rs
+++ b/crates/worker/src/features/http_requests.rs
@@ -1,0 +1,33 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+
+#[derive(Deserialize, Clone, Default)]
+pub struct HttpRequests {
+    /// List of allowed domains to perform the calls
+    #[serde(default)]
+    pub allowed_hosts: Vec<String>,
+    /// List of allowed HTTP methods for the worker
+    #[serde(default = "default_methods")]
+    pub allowed_methods: Vec<String>,
+    /// Force an SSL connection in all hosts
+    #[serde(default = "default_true")]
+    pub force_https: bool,
+}
+
+/// Enable the configuration parameter by default
+fn default_true() -> bool {
+    true
+}
+
+/// It allows only basic methods by default
+fn default_methods() -> Vec<String> {
+    Vec::from([
+        String::from("GET"),
+        String::from("POST"),
+        String::from("PUT"),
+        String::from("PATCH"),
+        String::from("DELETE"),
+    ])
+}

--- a/crates/worker/src/features/mod.rs
+++ b/crates/worker/src/features/mod.rs
@@ -1,0 +1,6 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod data;
+pub mod folders;
+pub mod http_requests;

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod bindings;
 pub mod config;
+pub mod features;
 pub mod io;
 mod stdio;
 
@@ -57,10 +58,11 @@ impl Worker {
         let mut config = Config::default();
 
         if fs::metadata(&config_path).is_ok() {
-            if let Ok(c) = Config::try_from_file(config_path) {
-                config = c;
-            } else {
-                println!("Error loading the config!");
+            match Config::try_from_file(config_path) {
+                Ok(c) => config = c,
+                Err(e) => {
+                    eprintln!("Error loading the worker configuration: {}", e);
+                }
             }
         }
 
@@ -138,7 +140,9 @@ impl Worker {
         let wasi = wasi_builder.build();
         let state = WorkerState {
             wasi,
-            http: HttpBindings {},
+            http: HttpBindings {
+                http_config: self.config.features.http_requests.clone(),
+            },
         };
         let mut store = Store::new(&self.engine, state);
 

--- a/examples/go-fetch/index.toml
+++ b/examples/go-fetch/index.toml
@@ -1,0 +1,6 @@
+name = "go-fetch"
+version = "1"
+
+[features]
+[features.http_requests]
+allowed_hosts = ["jsonplaceholder.typicode.com"]

--- a/examples/js-fetch/index.toml
+++ b/examples/js-fetch/index.toml
@@ -1,0 +1,6 @@
+name = "js-fetch"
+version = "1"
+
+[features]
+[features.http_requests]
+allowed_hosts = ["jsonplaceholder.typicode.com"]

--- a/examples/rust-fetch/index.toml
+++ b/examples/rust-fetch/index.toml
@@ -1,0 +1,6 @@
+name = "rust-fetch"
+version = "1"
+
+[features]
+[features.http_requests]
+allowed_hosts = ["jsonplaceholder.typicode.com"]


### PR DESCRIPTION
In Wasm Workers Server, we want to follow the capability-based model that Wasm and WASI are enforcing. By default, workers cannot make HTTP requests. To enable it, you need to add a related configuration for the worker and enable only the specific requests you want.

For example:

```toml
name = "js-fetch"
version = "1"

[features]
[features.http_requests]
allowed_methods = ["GET"]
allowed_hosts = ["jsonplaceholder.typicode.com"]
allow_http = false
```

The default values for these config params are:

| Param | Default value |
| --- | --- |
| allowed_methods | `["GET", "POST", "PUT", "PATCH", "DELETE"]` |
| allowed_hosts | `[]` |
| allow_http | `false` | 

It refs #165 