### PR TITLE
update: bump env_logger to avoid using atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,7 +3164,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "clap 4.3.4",
- "env_logger 0.9.3",
+ "env_logger 0.10.0",
  "prettytable-rs",
  "reqwest",
  "wws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 actix-web = { workspace = true }
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 clap = { version = "4.0.10", features = ["derive"] }
 prettytable-rs = "0.10.0"
 wws-config = { workspace = true }


### PR DESCRIPTION
Update `env_logger` to `0.10.0` to stop using `atty`. This library is still used by the JavaScript QuickJS engine, but as a `build-dependency` so it's fine:

```
$ cargo tree -i -p atty

atty v0.2.14
├── clap v3.2.25
│   └── bindgen v0.60.1
│       [build-dependencies]
│       └── quickjs-wasm-sys v1.0.0
│           └── quickjs-wasm-rs v1.0.0
│               └── javy v1.0.0
│                   └── wasm-workers-quick-js-engine v0.1.0 (/Users/dangel/Workspace/octo/webassembly-functionless/kits/javascript)
└── env_logger v0.9.3
    └── bindgen v0.60.1 (*)
```

It closes #170 