### PR TITLE
feat: add lib.rs with gated child crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,12 @@ wws-project = { workspace = true }
 reqwest = { version = "0.11", features = ["blocking"] }
 
 [features]
+default = ["all"]
+all = ["wws_config", "wws_router", "wws_server"]
+wws_config = []
+wws_router = []
+wws_server = []
+
 vendored-openssl = ["wws-project/vendored-openssl"]
 
 [workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(feature = "wws_config")]
+pub use wws_config;
+#[cfg(feature = "wws_router")]
+pub use wws_router;
+#[cfg(feature = "wws_server")]
+pub use wws_server;


### PR DESCRIPTION
This allows for Wasm Workers Consumers to depend on the toplevel WWS crate as a library, gating different features behind cargo features.

The cargo features that will permeate in the toplevel `lib.rs` depend on the usage that third parties will make of our API and I think is worth adding as needed.

This change keeps the ability for third parties to consume explicit subcrates if they want. However, if they consume more than one subcrate, when they bump the WWS version, they will need to do so in different places in their `Cargo.toml`. This toplevel `lib.rs` helps in this regard, by allowing a consumer to depend on the toplevel `lib.rs`, and only activate the features they need through Cargo features.