### PR TITLE
chore: bump rust to 1.71.0 and use vendored openssl

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -26,6 +26,8 @@ RUN set -eux; \
 
 FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 ARG WWS_BUILD_DIR=/usr/src/wws
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates
 RUN mkdir -p /app
 RUN mkdir -p /opt
 COPY --from=build-wws ${WWS_BUILD_DIR}/build/wws /opt

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,12 +1,15 @@
 # Build wasm_runtime in release mode
 
 
-FROM --platform=$TARGETPLATFORM rust:1.64.0-slim as build-wws
+FROM --platform=$TARGETPLATFORM rust:1.71.0-slim as build-wws
 ARG WWS_BUILD_DIR=/usr/src/wws
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 WORKDIR $WWS_BUILD_DIR
 COPY ./ $WWS_BUILD_DIR/
+RUN echo "Installing build prerequisites"
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential
 RUN echo "Running on ${BUILDPLATFORM}, building for ${TARGETPLATFORM}"
 RUN set -eux; \
     ls -l .; \
@@ -16,7 +19,7 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: $BUILDPLATFORM"; exit 1 ;; \
     esac; \
     rustup target add $bldArch; \
-    cargo build --release --target=$bldArch; \
+    cargo build --release --features vendored-openssl --target=$bldArch; \
     mkdir ./build; \
     cp ./target/$bldArch/release/wws ./build/wws
 
@@ -28,4 +31,3 @@ RUN mkdir -p /opt
 COPY --from=build-wws ${WWS_BUILD_DIR}/build/wws /opt
 
 CMD ["/opt/wws", "/app/", "--host", "0.0.0.0"]
-


### PR DESCRIPTION
Fixes: https://github.com/vmware-labs/wasm-workers-server/issues/183