### PR TITLE
chore: place wws under /opt/wws and keep /app in prebuilt images too

### DIFF
--- a/image/Prebuilt.dockerfile
+++ b/image/Prebuilt.dockerfile
@@ -3,7 +3,8 @@
 # GitHub actions
 
 # Retrieve the certificates to install runtimes later on.
-FROM --platform=$TARGETPLATFORM bitnami/minideb:latest AS certs
+FROM --platform=$TARGETPLATFORM bitnami/minideb:latest AS sysroot
+RUN mkdir -p /target/app /target/opt
 RUN install_packages ca-certificates
 
 # Build the final image
@@ -14,9 +15,10 @@ LABEL org.opencontainers.image.source=https://github.com/vmware-labs/wasm-worker
 LABEL org.opencontainers.image.description="Wasm Workers Server is a blazing-fast self-contained server that routes HTTP requests to workers in your filesystem. Everything run in a WebAssembly sandbox."
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --chmod=755 ./wws-$TARGETARCH /wws
+COPY --from=sysroot /target/app /app
+COPY --from=sysroot /target/opt /opt
+COPY --from=sysroot /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --chmod=755 ./wws-$TARGETARCH /opt/wws
 
-ENTRYPOINT ["/wws"]
+ENTRYPOINT ["/opt/wws"]
 CMD ["/app/", "--host", "0.0.0.0"]
-


### PR DESCRIPTION
Place wws under /opt in the container images that use prebuilt binaries, in the same place as the container images that build the project to reduce the drift and surprises depending if a user build the container on their own machine, or if they pull `ghcr.io/vmware-labs/wws:preview` for example.