### PR TITLE
fix: update Dockerfile

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -31,5 +31,5 @@ RUN apt-get update && \
 RUN mkdir -p /app
 RUN mkdir -p /opt
 COPY --from=build-wws ${WWS_BUILD_DIR}/build/wws /opt
-
-CMD ["/opt/wws", "/app/", "--host", "0.0.0.0"]
+ENTRYPOINT ["/opt/wws"]
+CMD ["/app/", "--host", "0.0.0.0"]

--- a/image/Prebuilt.dockerfile
+++ b/image/Prebuilt.dockerfile
@@ -17,5 +17,6 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --chmod=755 ./wws-$TARGETARCH /wws
 
-CMD ["/wws", "/app/", "--host", "0.0.0.0"]
+ENTRYPOINT ["/wws"]
+CMD ["/app/", "--host", "0.0.0.0"]
 


### PR DESCRIPTION
I increased the `ENTRYPOINT` in the Dockerfile to default to the path to the wws executable.

And the `CMD` command can override the default value when running the image.

Fixes: #166