### PR TITLE
fix rust language example

### DIFF
--- a/docs/docs/languages/rust.md
+++ b/docs/docs/languages/rust.md
@@ -58,10 +58,11 @@ In this example, the worker will get a request and print all the related informa
     use wasm_workers_rs::{
         worker,
         http::{self, HeaderValue, Request, Response},
+        Content,
     };
 
     #[worker]
-    fn reply(req: Request<String>) -> Result<Response<String>> {
+    fn reply(req: Request<String>) -> Result<Response<Content>> {
         // Applied changes here to use the Response method. This requires changes
         // on signature and how it returns the data.
         let response = format!(


### PR DESCRIPTION
First of all, thank you for this great piece of software!

Following the [rust language example](https://workers.wasmlabs.dev/docs/languages/rust) lead to the following error:

```bash
cargo build --release --target wasm32-wasi
   Compiling worker v0.1.0 (/Users/c.voigt/tmp/wws/worker)
error[E0308]: mismatched types
  --> src/main.rs:7:1
   |
7  | #[worker]
   | ^^^^^^^^^
   | |
   | expected enum `Content`, found struct `String`
   | arguments to this function are incorrect
   |
   = note: expected struct `Response<Content>`
              found struct `Response<String>`
note: associated function defined here
  --> /Users/c.voigt/.cargo/git/checkouts/wasm-workers-server-167282fd3427d500/93e1165/kits/rust/src/io.rs:86:12
   |
86 |     pub fn from_response(response: Response<Content>, cache: HashMap<String, String>) -> Self {
   |            ^^^^^^^^^^^^^
   = note: this error originates in the attribute macro `worker` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0308`.
error: could not compile `worker` due to previous error
```

I was able to run the example with the attached adjustments.

