### PR TITLE
feat(server): add `--cors` argument to enable cors for all workers

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -37,6 +37,7 @@ pub async fn serve(
     port: u16,
     panel: bool,
     stderr: Option<&Path>,
+    cors_origins: Option<Vec<String>>,
 ) -> Result<Server> {
     // Initializes the data connectors. For now, just KV
     let data = Data::new(RwLock::new(DataConnectors::default()));
@@ -53,6 +54,8 @@ pub async fn serve(
         stderr_file = Data::new(None);
     }
 
+    let cors_data = Data::new(cors_origins);
+
     let server = HttpServer::new(move || {
         let mut app = App::new()
             // enable logger
@@ -62,7 +65,8 @@ pub async fn serve(
             .app_data(Data::clone(&routes))
             .app_data(Data::clone(&data))
             .app_data(Data::clone(&root_path))
-            .app_data(Data::clone(&stderr_file));
+            .app_data(Data::clone(&stderr_file))
+            .app_data(Data::clone(&cors_data));
 
         // Configure panel
         if panel {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,10 @@ pub struct Args {
     /// Manage language runtimes in your project
     #[command(subcommand)]
     commands: Option<Main>,
+
+    /// CORS headers to add to all workers if not already set by the worker
+    #[arg(long)]
+    cors: Option<Vec<String>>,
 }
 
 #[actix_web::main]
@@ -198,6 +202,7 @@ async fn main() -> std::io::Result<()> {
             args.port,
             args.enable_panel,
             None,
+            args.cors,
         )
         .await
         .map_err(|err| Error::new(ErrorKind::AddrInUse, err))?;


### PR DESCRIPTION
This PR will add the support for configuring origins to enable CORS for all the workers. If the worker has setup `Access-Control-Allow-Origin` then it will be respected. Multiple origins can be passed using the `--cors` flag. This is a simple example

```bash
wws --cors https://example.com .
```

This will add `https://example.com` to all the workers who do not have  `Access-Control-Allow-Origin` header configured.