### PR TITLE
chore: remove stderr path

### DIFF
--- a/crates/worker/src/stdio.rs
+++ b/crates/worker/src/stdio.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Cursor};
+use std::io::Cursor;
 use wasi_common::pipe::{ReadPipe, WritePipe};
 use wasmtime_wasi::WasiCtxBuilder;
 
@@ -6,51 +6,28 @@ use wasmtime_wasi::WasiCtxBuilder;
 /// Note that currently, wws relies on stdin and stdout
 /// to send and read data from the worker.
 ///
-/// The stderr is configurable just to cover use cases in which
-/// wws is used as a library and we want to expose the logs
-///
-/// @see https://github.com/vmware-labs/wasm-workers-server/issues/125
-///
 /// The stdin/stdout approach will change in the future with
-/// a more performant and appropiate way.
+/// a more performant and appropiate approach.
 pub struct Stdio {
     /// Defines the stdin ReadPipe to send the data to the module
     pub stdin: ReadPipe<Cursor<String>>,
     /// Defines the stdout to extract the data from the module
     pub stdout: WritePipe<Cursor<Vec<u8>>>,
-    /// Defines the stderr to expose logs from inside the module
-    pub stderr: Option<WritePipe<File>>,
 }
 
 impl Stdio {
     /// Initialize the stdio. The stdin will contain the input data.
-    pub fn new(input: &str, stderr_file: Option<File>) -> Self {
-        let stderr;
-
-        if let Some(file) = stderr_file {
-            stderr = Some(WritePipe::new(file));
-        } else {
-            stderr = None
-        }
-
+    pub fn new(input: &str) -> Self {
         Self {
             stdin: ReadPipe::from(input),
             stdout: WritePipe::new_in_memory(),
-            stderr,
         }
     }
 
     pub fn configure_wasi_ctx(&self, builder: WasiCtxBuilder) -> WasiCtxBuilder {
-        let builder = builder
+        builder
             .stdin(Box::new(self.stdin.clone()))
-            .stdout(Box::new(self.stdout.clone()));
-
-        // Set stderr if it was previously configured. If not, inherit
-        // it from the environment
-        if let Some(pipe) = self.stderr.clone() {
-            builder.stderr(Box::new(pipe))
-        } else {
-            builder.inherit_stderr()
-        }
+            .stdout(Box::new(self.stdout.clone()))
+            .inherit_stderr()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,6 @@ async fn main() -> std::io::Result<()> {
             hostname: args.hostname.clone(),
             port: args.port,
             panel: args.enable_panel.into(),
-            stderr: None,
             cors_origins: args.cors,
         })
         .await


### PR DESCRIPTION
Inherit stderr from the host, so that workers have the chance to log information through their stderr, that will end up in the host side (let it be the WWS binary itself running standalone, or through runwasi, for example).