### PR TITLE
feat: load static assets manually so all other requests rely on wasm_handler

### DIFF
--- a/crates/server/src/handlers/assets.rs
+++ b/crates/server/src/handlers/assets.rs
@@ -11,7 +11,7 @@ use std::io::{Error, ErrorKind};
 /// like "public/{uri}/index.html" and "public/{uri}.html".
 ///
 /// If no file is present, it will try to get a default "public/404.html"
-pub async fn handle_assets(req: &HttpRequest) -> Result<NamedFile, Error> {
+pub async fn handle_assets(req: HttpRequest) -> Result<NamedFile, Error> {
     let root_path = &req
         .app_data::<Data<AppData>>()
         .expect("error fetching app data")
@@ -25,7 +25,7 @@ pub async fn handle_assets(req: &HttpRequest) -> Result<NamedFile, Error> {
     // Same as before, but the file is located at ./about.html
     let html_ext_path = root_path.join(format!("public{uri_path}.html"));
 
-    if file_path.exists() {
+    if file_path.exists() && !uri_path.is_empty() && uri_path != "/" {
         NamedFile::open_async(file_path).await
     } else if uri_path.ends_with('/') && index_folder_path.exists() {
         NamedFile::open_async(index_folder_path).await

--- a/crates/server/src/handlers/worker.rs
+++ b/crates/server/src/handlers/worker.rs
@@ -1,7 +1,7 @@
-// Copyright 2022 VMware, Inc.
+// Copyright 2022-2023 VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{assets::handle_assets, not_found::handle_not_found};
+use super::not_found::handle_not_found;
 use crate::{AppData, DataConnectors};
 use actix_web::{
     http::StatusCode,
@@ -42,16 +42,8 @@ pub async fn handle_worker(req: HttpRequest, body: Bytes) -> HttpResponse {
 
     // First, we need to identify the best suited route
     let selected_route = app_data.routes.retrieve_best_route(req.path());
-    if let Some(route) = selected_route {
-        // First, check if there's an existing static file. Static assets have more priority
-        // than dynamic routes. However, I cannot set the static assets as the first service
-        // as it's captures everything.
-        if route.is_dynamic() {
-            if let Ok(existing_file) = handle_assets(&req).await {
-                return existing_file.into_response(&req);
-            }
-        }
 
+    if let Some(route) = selected_route {
         let workers = WORKERS
             .read()
             .expect("error locking worker lock for reading");

--- a/crates/server/src/static_assets.rs
+++ b/crates/server/src/static_assets.rs
@@ -1,0 +1,99 @@
+// Copyright 2023 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    ffi::OsStr,
+    io::Error as IoError,
+    path::{Path, PathBuf},
+};
+
+/// Folder that contains the static assets in a wws project
+pub const STATIC_ASSETS_FOLDER: &str = "public";
+
+/// Load and stores the information of static assets
+/// in Wasm Workers Server. It enables to manually set
+/// the list of routes in actix.
+#[derive(Default)]
+pub struct StaticAssets {
+    /// Static assets folder
+    folder: PathBuf,
+    /// The initial prefix to mount the static assets
+    prefix: String,
+    /// List of local paths to set in actix
+    pub paths: Vec<String>,
+}
+
+impl StaticAssets {
+    /// Creates a new instance by looking at the public
+    /// folder if exists.
+    pub fn new(root_path: &Path, prefix: &str) -> Self {
+        Self {
+            folder: root_path.join(STATIC_ASSETS_FOLDER),
+            prefix: prefix.to_string(),
+            paths: Vec::new(),
+        }
+    }
+
+    /// Load the assets in the public folder.
+    pub fn load(&mut self) -> Result<(), IoError> {
+        if self.folder.exists() {
+            // Set the provided prefix
+            let prefix = self.prefix.clone();
+
+            self.load_folder(&self.folder.clone(), &prefix)?;
+        }
+
+        Ok(())
+    }
+
+    /// Load the assets from a specific folder
+    fn load_folder(&mut self, folder: &Path, prefix: &str) -> Result<(), IoError> {
+        let paths = folder.read_dir()?;
+
+        for path in paths {
+            let path = path?.path();
+
+            if path.is_dir() {
+                let folder_path = path
+                    .file_stem()
+                    .expect("Error reading the file stem from a static file")
+                    .to_string_lossy();
+
+                let new_prefix = format!("{}/{}", prefix, folder_path);
+                // Recursive
+                self.load_folder(&path, &new_prefix)?;
+            } else {
+                // Save the static file
+                match path.extension() {
+                    Some(ext) if ext == OsStr::new("html") => {
+                        let stem = path
+                            .file_stem()
+                            .expect("Error reading the file name from a static file")
+                            .to_string_lossy();
+
+                        // Add the full file path
+                        self.paths.push(format!("{prefix}/{stem}.html"));
+
+                        if stem == "index" {
+                            // For index files, mount it on the prefix (folder)
+                            self.paths.push(format!("{prefix}/"));
+                        } else {
+                            // Mount it without the .html (pretty routes)
+                            self.paths.push(format!("{prefix}/{stem}"));
+                        }
+                    }
+                    _ => {
+                        let name = path
+                            .file_name()
+                            .expect("Error reading the file name from a static file")
+                            .to_string_lossy();
+
+                        self.paths.push(format!("{prefix}/{name}"));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is the first PR to complete #175. Before this PR, the default service that captured any non-processed request was the `actix-files` service ([via `Files`](https://docs.rs/actix-files/0.6.2/actix_files/struct.Files.html)). Since we wanted to mount static files into `/`, `Files` was capturing al `/.*` routes. For workers, `wws` was mounting their routes explicitly. 

In #175, our intention is the opposite. We want `workers_handler` to manage any unknown route, so we can add new routes when the server is running. My first approach was to find a way to pass a request to `worker_handler` from `Files` using the `default_handler`. The `Files` service triggers this handler when it doesn't find any matching file. However, the types didn't match and it was an extra step before processing the request.

For this reason, I changed the approach and set all the static assets routes manually. Then, `wws` sends any unknown route to the `wasm_handler` to detect if there's any worker that manages it. In fact, this is a more correct approach as static files have a higher priority than workers (like dynamic).