### PR TITLE
fix: call to the toString method when Response receives a String object

### DIFF
--- a/kits/javascript/shims/types/response.js
+++ b/kits/javascript/shims/types/response.js
@@ -9,7 +9,12 @@ import httpStatus from "http-status";
 // It contains different helpers
 class Response {
   constructor(body, options = {}) {
-    this.body = body;
+    // Process the body
+    if (body instanceof String) {
+      this.body = body.toString();
+    } else {
+      this.body = body;
+    }
 
     if (options.headers instanceof Headers) {
       this.headers = options.headers;


### PR DESCRIPTION
Call the `toString` to convert the current String object into a string primitive. After applying this change, `wws` returns the proper response when running the #238 example:

```
$ curl localhost:8080/test
<!DOCTYPE html>
      <h1>Hello! test!</h1>
```

It fixes #238 