### PR TITLE
feat: show stack traces when capturing errors in the handler

### DIFF
--- a/kits/javascript/shims/index.js
+++ b/kits/javascript/shims/index.js
@@ -55,7 +55,7 @@ const requestToHandler = input => {
         error = `Couldn't process the response from the handler:\n${err}`;
       });
   } catch (err) {
-    error = `There was an error running the handler:\n${err}`;
+    error = `There was an error running the handler:\n${err}\n${err.stack}`;
   }
 };
 


### PR DESCRIPTION
Display JS stack traces when there's an error:

**Before**

```
There was an error running the handler:
TypeError: not a function
```

**After**

```
There was an error running the handler:
TypeError: not a function
    at errorHandler (handler.mjs:3748)
    at handleError (handler.mjs:3914)
    at dispatch (handler.mjs:3938)
    at <anonymous> (handler.mjs:3768)
    at <anonymous> (runtime.mjs)
    at requestToHandler (handler.mjs:2962)
```

It closes #246 