### PR TITLE
fix: add missing console.trace method

### DIFF
--- a/kits/javascript/shims/bindings.js
+++ b/kits/javascript/shims/bindings.js
@@ -53,6 +53,9 @@ import { Response } from "./types/response";
     },
     warn(msg) {
       this.log(msg);
+    },
+    trace(msg) {
+      this.log(msg);
     }
   }
 


### PR DESCRIPTION
Add the missing `console.trace` method to the JavaScript SDK.

It closes #248 