### PR TITLE
feat: start using rustls instead of openssl

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -18,14 +18,14 @@ jobs:
             platform: unknown-linux-musl
             cross: false
             name: linux-musl
-            features: --features vendored-openssl
+            features:
           - build: linux
             arch: aarch64
             os: ubuntu-latest
             platform: unknown-linux-musl
             cross: true
             name: linux-musl
-            features: --features vendored-openssl
+            features:
           - build: windows
             arch: x86_64
             os: windows-latest
@@ -53,7 +53,7 @@ jobs:
             platform: apple-darwin
             cross: false
             name: macos-darwin
-            features: --features vendored-openssl
+            features:
     runs-on: ${{ matrix.os }}
     env:
       # This variable can be overriden with `cross` for builds that

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+"
+  # TODO: Remove it
+  pull_request:
+    branches: [ "main", "v[0-9]+.[0-9]+" ]
 
 jobs:
   build:

--- a/.github/workflows/container-preview.yml
+++ b/.github/workflows/container-preview.yml
@@ -45,7 +45,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install musl-tools
     - name: Build
-      run: ${{env.CARGO}} build --release --target=${{ matrix.arch }}-${{ matrix.platform }} --features vendored-openssl
+      run: ${{env.CARGO}} build --release --target=${{ matrix.arch }}-${{ matrix.platform }}
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -46,7 +46,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install musl-tools
     - name: Build
-      run: ${{env.CARGO}} build --release --target=${{ matrix.arch }}-${{ matrix.platform }} --features vendored-openssl
+      run: ${{env.CARGO}} build --release --target=${{ matrix.arch }}-${{ matrix.platform }}
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,15 +1857,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.1.5+3.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559068e4c12950d7dcaa1857a61725c0d38d4fc03ff8e070ab31a75d6e316491"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,7 +1864,6 @@ checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2233,6 +2223,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2244,6 +2235,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2317,6 +2322,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2378,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -2526,6 +2563,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "sptr"
@@ -2868,6 +2911,12 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3956,7 +4005,6 @@ name = "wws-project"
 version = "1.7.0"
 dependencies = [
  "git2",
- "openssl",
  "path-slash",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ wws-server = { workspace = true }
 wws-project = { workspace = true }
 
 [dev-dependencies]
-reqwest = { version = "0.11", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["rustls", "blocking"] }
 
 [features]
 default = ["all"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,6 @@ wws_config = []
 wws_router = []
 wws_server = []
 
-vendored-openssl = ["wws-project/vendored-openssl"]
-
 [workspace]
 members = [
   "crates/api-manage",
@@ -77,7 +75,7 @@ exclude = [
 [workspace.dependencies]
 actix-web = "4"
 lazy_static = "1.4.0"
-reqwest = "0.11"
+reqwest = { version = "0.11", features = ["rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.85"
 tokio = "1.28"
@@ -99,4 +97,3 @@ wasmtime-wasi = "13.0.0"
 wasmtime-wasi-nn = "13.0.0"
 wasi-common = "13.0.0"
 path-slash = "0.2.1"
-openssl = { version = "=0.10.55" }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -16,11 +16,6 @@ wws-store = { workspace = true }
 url = "2.3.1"
 sha256 = "1.1.1"
 git2 = "0.17.2"
-# Not all platforms require OpenSSL
-openssl = { workspace = true, optional = true }
-
-[features]
-vendored-openssl = ["openssl/vendored"]
 
 [dev-dependencies]
 path-slash = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -33,7 +33,7 @@ exclude = [
     "wit-bindgen-wasmtime",
     "wit-bindgen-gen-wasmtime",
     "wit-bindgen-gen-rust",
-    "wit-bindgen-gen-core"
+    "wit-bindgen-gen-core",
 ]
 
 # More documentation for the advisories section can be found here:
@@ -63,9 +63,16 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
+    "OpenSSL",
     "Unicode-DFS-2016",
-    "Zlib"
+    "Zlib",
 ]
+
+# Special case for Ring, which includes multiple licenses
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,6 +1,4 @@
 # Build wasm_runtime in release mode
-
-
 FROM --platform=$TARGETPLATFORM rust:1.71.0-slim as build-wws
 ARG WWS_BUILD_DIR=/usr/src/wws
 ARG TARGETPLATFORM
@@ -19,15 +17,13 @@ RUN set -eux; \
         *) echo >&2 "unsupported architecture: $BUILDPLATFORM"; exit 1 ;; \
     esac; \
     rustup target add $bldArch; \
-    cargo build --release --features vendored-openssl --target=$bldArch; \
+    cargo build --release --target=$bldArch; \
     mkdir ./build; \
     cp ./target/$bldArch/release/wws ./build/wws
 
-
+# Build the image
 FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 ARG WWS_BUILD_DIR=/usr/src/wws
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates
 RUN mkdir -p /app
 RUN mkdir -p /opt
 COPY --from=build-wws ${WWS_BUILD_DIR}/build/wws /opt

--- a/image/Prebuilt.dockerfile
+++ b/image/Prebuilt.dockerfile
@@ -2,10 +2,9 @@
 # is mainly used to build the preview / release container images in
 # GitHub actions
 
-# Retrieve the certificates to install runtimes later on.
+# Create the folders for the main container
 FROM --platform=$TARGETPLATFORM bitnami/minideb:latest AS sysroot
 RUN mkdir -p /target/app /target/opt
-RUN install_packages ca-certificates
 
 # Build the final image
 FROM --platform=$TARGETPLATFORM scratch
@@ -17,7 +16,6 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=sysroot /target/app /app
 COPY --from=sysroot /target/opt /opt
-COPY --from=sysroot /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --chmod=755 ./wws-$TARGETARCH /opt/wws
 
 ENTRYPOINT ["/opt/wws"]


### PR DESCRIPTION
Before, `wws` was using OpenSSL to establish external connections using the `reqwest` crate. Initially, we wanted to use `rustls`, but the compilation was failing for Windows arm64. After closing all the tasks described in #137, we can now switch to `rustls`.

In the past, we had multiple issues and CVEs due to the OpenSSL dependency. In addition to that, we had to compile it from scratch on every build so it was taking extra time. Also, we had to include `ca-certificates` in the containers images as we are using `scratch`. From now on, we will rely on `rustls` related certs (webpki).

It closes #137