### PR TITLE
feat: improve JavaScript performance by caching the runtime + polyfill

### DIFF
--- a/kits/javascript/Cargo.lock
+++ b/kits/javascript/Cargo.lock
@@ -897,6 +897,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "javy",
+ "once_cell",
  "regex",
  "wit-bindgen-rust",
 ]

--- a/kits/javascript/Cargo.toml
+++ b/kits/javascript/Cargo.toml
@@ -11,3 +11,4 @@ javy = { version = "2.0.0", features = ["json"] }
 regex = "1.10.1"
 # Use an old version until we add support for components.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "cb871cfa1ee460b51eb1d144b175b9aab9c50aba" }
+once_cell = "1.18.0"

--- a/kits/javascript/Makefile
+++ b/kits/javascript/Makefile
@@ -1,5 +1,7 @@
-.PHONY: build
+.PHONY: build build-src
 
-build:
-	cargo build --target wasm32-wasi --release && \
-	cp ./target/wasm32-wasi/release/wasm-workers-quick-js-engine.wasm ./
+build-src:
+	cargo build --target wasm32-wasi --release
+
+build: build-src
+	wizer --allow-wasi --wasm-bulk-memory true -o ./wasm-workers-quick-js-engine.wasm ./target/wasm32-wasi/release/wasm-workers-quick-js-engine.wasm

--- a/kits/javascript/src/error.rs
+++ b/kits/javascript/src/error.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// List of runtime errors
+#[derive(Debug)]
 pub enum RuntimeError {
     InvalidBinding { invalid_export: String },
 }


### PR DESCRIPTION
Update the JS runtime to cache the runtime and the given polyfill. After caching it, the worker doesn't need to compile it to bytecode and evaluate it on every run. To accomplish it, we are following an approach similar to [Javy](https://github.com/bytecodealliance/javy). To precompile the polyfill, we use the [`wizer` tool](https://github.com/bytecodealliance/wizer). It pre-initializes the JS runtime with the evaluated polyfill. On runtime, the engine only retrieves the preconfigured runtime and compile the user code.

The results are pretty amazing 👇 

It closes #242 

## Quick benchmarks

_Note that I didn't prepare any special environment for the bechmarks, so they are illustrative_

### Js-basic example

_5000 requests, 20 req/s_

| Runtime | Req/s | Fastest (ms) | Slowest (ms) | Avg (ms) | p90 (ms) | Improvement |
| --- | --- | --- | --- | --- | --- | --- |
| No Cache | 82 | 106 | 355 | 241 | 258 | - | 
| Cache | 1164 | 2,5 | 49,7 | 17,1 | 21 |  <b>x12 faster</b> |

<details>
<summary>See "No Cache" logs</summary>

```
$ hey -c 20 -n 5000 http://127.0.0.1:8080/

Summary:
  Total:        60.8004 secs
  Slowest:      0.3555 secs
  Fastest:      0.1060 secs
  Average:      0.2419 secs
  Requests/sec: 82.2363

  Total data:   3865000 bytes
  Size/request: 773 bytes

Response time histogram:
  0.106 [1]     |
  0.131 [0]     |
  0.156 [10]    |
  0.181 [0]     |
  0.206 [0]     |
  0.231 [847]   |■■■■■■■■■■
  0.256 [3496]  |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.281 [605]   |■■■■■■■
  0.306 [31]    |
  0.331 [8]     |
  0.356 [2]     |


Latency distribution:
  10% in 0.2277 secs
  25% in 0.2334 secs
  50% in 0.2406 secs
  75% in 0.2490 secs
  90% in 0.2581 secs
  95% in 0.2638 secs
  99% in 0.2775 secs

Details (average, fastest, slowest):
  DNS+dialup:   0.0000 secs, 0.1060 secs, 0.3555 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:    0.0000 secs, 0.0000 secs, 0.0037 secs
  resp wait:    0.2418 secs, 0.1059 secs, 0.3553 secs
  resp read:    0.0001 secs, 0.0000 secs, 0.0046 secs

Status code distribution:
  [200] 5000 responses
```

</details>

<details>
<summary>See "Cache" logs</summary>

```
$ hey -c 20 -n 5000 http://127.0.0.1:8080/

Summary:
  Total:        4.2936 secs
  Slowest:      0.0497 secs
  Fastest:      0.0025 secs
  Average:      0.0171 secs
  Requests/sec: 1164.5112

  Total data:   3865000 bytes
  Size/request: 773 bytes

Response time histogram:
  0.002 [1]     |
  0.007 [18]    |
  0.012 [114]   |■■
  0.017 [2317]  |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.021 [2116]  |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.026 [344]   |■■■■■■
  0.031 [64]    |■
  0.036 [14]    |
  0.040 [9]     |
  0.045 [1]     |
  0.050 [2]     |


Latency distribution:
  10% in 0.0135 secs
  25% in 0.0150 secs
  50% in 0.0167 secs
  75% in 0.0187 secs
  90% in 0.0210 secs
  95% in 0.0228 secs
  99% in 0.0278 secs

Details (average, fastest, slowest):
  DNS+dialup:   0.0000 secs, 0.0025 secs, 0.0497 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:    0.0000 secs, 0.0000 secs, 0.0005 secs
  resp wait:    0.0170 secs, 0.0024 secs, 0.0496 secs
  resp read:    0.0000 secs, 0.0000 secs, 0.0008 secs

Status code distribution:
  [200] 5000 responses
```

</details>

### Hono example

| Runtime | Req/s | Fastest (ms) | Slowest (ms) | Avg (ms) | p90 (ms) | Improvement | 
| --- | --- | --- | --- | --- | --- | --- |
| No cache | 79 | 108 | 360 | 251 | 266  | - |
| Cache | 926 | 6,8 | 40,8 | 21,4 | 26,8 | <b>x10 faster</b> |

<details>
<summary>See "No Cache" logs</summary>

```
$ hey -c 20 -n 5000 http://127.0.0.1:8080/

Summary:
  Total:        63.0051 secs
  Slowest:      0.3599 secs
  Fastest:      0.1088 secs
  Average:      0.2511 secs
  Requests/sec: 79.3587

  Total data:   235000 bytes
  Size/request: 47 bytes

Response time histogram:
  0.109 [1]     |
  0.134 [5]     |
  0.159 [5]     |
  0.184 [2]     |
  0.209 [3]     |
  0.234 [246]   |■■■
  0.259 [3640]  |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.285 [1010]  |■■■■■■■■■■■
  0.310 [69]    |■
  0.335 [12]    |
  0.360 [7]     |


Latency distribution:
  10% in 0.2372 secs
  25% in 0.2427 secs
  50% in 0.2500 secs
  75% in 0.2581 secs
  90% in 0.2664 secs
  95% in 0.2728 secs
  99% in 0.2921 secs

Details (average, fastest, slowest):
  DNS+dialup:   0.0000 secs, 0.1088 secs, 0.3599 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:    0.0000 secs, 0.0000 secs, 0.0054 secs
  resp wait:    0.2510 secs, 0.1088 secs, 0.3599 secs
  resp read:    0.0001 secs, 0.0000 secs, 0.0072 secs

Status code distribution:
  [200] 5000 responses
```

</details>

<details>
<summary>See "Cache" logs</summary>

```
$ hey -c 20 -n 5000 http://127.0.0.1:8080/

Summary:
  Total:        5.3946 secs
  Slowest:      0.0409 secs
  Fastest:      0.0068 secs
  Average:      0.0214 secs
  Requests/sec: 926.8519

  Total data:   235000 bytes
  Size/request: 47 bytes

Response time histogram:
  0.007 [1]     |
  0.010 [9]     |
  0.014 [7]     |
  0.017 [395]   |■■■■■■■■
  0.020 [1876]  |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.024 [1552]  |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.027 [732]   |■■■■■■■■■■■■■■■■
  0.031 [310]   |■■■■■■■
  0.034 [91]    |■■
  0.037 [20]    |
  0.041 [7]     |


Latency distribution:
  10% in 0.0172 secs
  25% in 0.0187 secs
  50% in 0.0207 secs
  75% in 0.0236 secs
  90% in 0.0268 secs
  95% in 0.0287 secs
  99% in 0.0328 secs

Details (average, fastest, slowest):
  DNS+dialup:   0.0000 secs, 0.0068 secs, 0.0409 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:    0.0000 secs, 0.0000 secs, 0.0006 secs
  resp wait:    0.0214 secs, 0.0067 secs, 0.0409 secs
  resp read:    0.0000 secs, 0.0000 secs, 0.0013 secs

Status code distribution:
  [200] 5000 responses
```

</details>