### PR TITLE
fix: add routes data for panel api endpoints

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -83,6 +83,7 @@ pub async fn serve(serve_options: ServeOptions) -> Result<Server> {
     let server = HttpServer::new(move || {
         // Initializes the app data for handlers
         let app_data: Data<AppData> = Data::new(serve_options.clone().into());
+        let routes_data: Data<Routes> = Data::new(app_data.routes.clone());
 
         let mut app = App::new()
             // enable logger
@@ -90,6 +91,7 @@ pub async fn serve(serve_options: ServeOptions) -> Result<Server> {
             // Clean path before sending it to the service
             .wrap(middleware::NormalizePath::trim())
             .app_data(Data::clone(&app_data))
+            .app_data(Data::clone(&routes_data))
             .app_data(Data::clone(&data_connectors));
 
         // Configure panel


### PR DESCRIPTION
When visiting the admin panel after running `wws --enable-panel`, we are presented with a loading spinner and the worker info never loads. With `RUST_LOG="actix_web=debug"`, we can see the following error when we access the panel at `https://127.0.0.1:8080/_panel`:

```
[2024-02-06T00:23:37Z DEBUG actix_web::data] Failed to extract `Data<wws_router::Routes>` for `handle_api_workers` handler. For the Data extractor to work correctly, wrap the data with `Data::new()` and pass it to `App::app_data()`. Ensure that types align in both the set and retrieve calls.
```

This PR adds Routes through the app's app_data for the api handler. I don't typically work in Rust, so let me know if there's a better/more preferred approach to solve this problem!

Note: The routes are available as part of the `AppData` that's already exposed to the Actix app, but adding `wws-server` as a dependency to `wws-api-manage` so we can reference the `AppData` type results in a circular dependency.